### PR TITLE
EOS-11662 Rename software update api as per provisioner's changes

### DIFF
--- a/csm/core/data/models/upgrade.py
+++ b/csm/core/data/models/upgrade.py
@@ -73,6 +73,7 @@ class UpdateStatusEntry(CsmModel):
     updated_at = DateTimeType()
     uploaded_at = DateTimeType()
     started_at = DateTimeType()
+    file_path = StringType()
 
     @classmethod
     def generate_new(cls, update_type):
@@ -89,6 +90,7 @@ class UpdateStatusEntry(CsmModel):
         model.updated_at = datetime.datetime.now()
         model.uploaded_at = None
         model.started_at = None
+        model.file_path = ""
 
         return model
 
@@ -126,7 +128,8 @@ class UpdateStatusEntry(CsmModel):
             "details": self.details,
             "uploaded_at": None,
             "started_at": None,
-            "updated_at": None
+            "updated_at": None,
+            "file_path": self.file_path
         }
 
         if self.updated_at:

--- a/csm/plugins/eos/provisioner.py
+++ b/csm/plugins/eos/provisioner.py
@@ -92,7 +92,7 @@ class ProvisionerPlugin:
             try:
                 # The version argument has no effect here, but we need to pass it anyway
                 version = self._generate_random_version()
-                self.provisioner.set_eosupdate_repo(version, path, dry_run=True)
+                self.provisioner.set_swupdate_repo(version, path, dry_run=True)
             except self.provisioner.errors.ProvisionerError as e:
                 raise PackageValidationError(f"Package validation failed: {e}")
 
@@ -119,8 +119,8 @@ class ProvisionerPlugin:
             try:
                 # Generating the version here as at the moment we cannot infer it from the package
                 # version = self._generate_random_version()
-                self.provisioner.set_eosupdate_repo(os.path.splitext(os.path.basename(path))[0], path)
-                return self.provisioner.eos_update(nowait=True)
+                self.provisioner.set_swupdate_repo(os.path.splitext(os.path.basename(path))[0], path)
+                return self.provisioner.sw_update(nowait=True)
             except Exception as e:
                 Log.exception(e)
                 raise CsmInternalError('Failed to start the software update process')


### PR DESCRIPTION
# BUG

## Problem Statement
<pre>
  <code>
Story Ref (if any): EOS-11812
 Get error when trying to upload software update file
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
   Get error when trying to upload software update file, due to provisioner api rename.
  </code>
</pre>
## Solution
<pre>
  <code>
    Updated software update api as per provisioner's changes. changed api as follows:
     set_eosupdate_repo ---> set_swupdate_repo
     eos_update              ---> sw_update
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
- Tested on local vm.
- tested with .iso file upload.
  </code>
</pre>
![1-sw](https://user-images.githubusercontent.com/66410054/90868556-9ca68a80-e3b4-11ea-91b4-0b6bbb98c4cf.png)