### PR TITLE
Resolve EOS-12336 Removed message_id from response if its not specified

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -127,7 +127,6 @@ class CsmRestApi(CsmApi, ABC):
     def error_response(err: Exception, request) -> dict:
         resp = {
             "error_code": None,
-            "message_id": None,
             "message": None,
         }
 
@@ -136,8 +135,10 @@ class CsmRestApi(CsmApi, ABC):
 
         if isinstance(err, CsmError):
             resp["error_code"] = err.rc()
-            resp["message_id"] = err.message_id()
             resp["message"] = err.error()
+            message_id = err.message_id()
+            if message_id is not None:
+                resp["message_id"] = err.message_id()
             message_args = err.message_args()
             if message_args is not None:
                 resp["error_format_args"] = err.message_args()


### PR DESCRIPTION
BUG
Problem Statement
  
Story Ref (if any): EOS-12336
 message_id is null in REST error response.

Unit testing on RPM done
  
  No
  
Problem Description
  
   In CsmError exception message_id is not consistently populated in all Exceptions calls.
  
Solution
  
    If message_id is null, removing it from REST response.
  
Unit Test Cases

1.PATCH call /api/v1/csm/users/nkpcsm4
body 
{
"old_password": "adbc2123@"
}

Output
{
    "error_code": "4099",
    "message": "Invalid request body: {'old_password': ['Password Policy Not Met.\\nMust contain at least one Uppercase Alphabet.']}"
}

2.  PATCH call /api/v1/csm/users/nkpcsm4
body 
{
}

{
    "error_code": "4099",
    "message": "Request effective body is empty",
    "message_id": "invalid request parameter"
}
Signed-off-by: Naval Patel <naval.patel@seagate.com>