### PR TITLE
Resolve EOS-12345 In stats response adding id only if its specified

### DIFF
--- a/csm/core/services/stats.py
+++ b/csm/core/services/stats.py
@@ -46,7 +46,8 @@ class StatsAppService(ApplicationService):
         """
         Log.debug(f"Get panel: {panel} stats")
         output = {}
-        output["id"]=stats_id
+        if stats_id:
+            output["id"]=stats_id
         panel_data =  await self._stats_provider.process_request(stats_id = stats_id, panel = panel,
                                                   from_t = from_t, duration_t = to_t,
                                                   metric_list = metric_list,
@@ -90,7 +91,8 @@ class StatsAppService(ApplicationService):
         """
         Log.debug(f"Get stats for panels: {panels_list}")
         output = {}
-        output["id"]=stats_id
+        if stats_id:
+            output["id"]=stats_id
         data_list = []
         for panel in panels_list:
             panel_data = await self._stats_provider.process_request(
@@ -131,7 +133,8 @@ class StatsAppService(ApplicationService):
         except:
             raise CsmInternalError("Stats: Invalid metric list %s" %metrics_list)
 
-        output["id"]=stats_id
+        if stats_id:
+            output["id"]=stats_id
         data_list = []
         for panel in panels.keys():
             panel_data = await self._stats_provider.process_request(


### PR DESCRIPTION
BUG
Problem Statement

Story Ref (if any): EOS-12345
ID is null in the REST API response for get stats command

Unit testing on RPM done

Yes

Problem Description

ID is null in the REST API response for get stats command

Solution

Displaying id only when its not null

Unit Test Cases
Tested with postman
GET {{baseurl}}/api/v1/stats?from=1597984500&to=1597984671&metric=throughput.read
{
    "metrics": [
        {
            "data": [
                [
                    1597984480000,
                    1597984490000,
                    1597984500000,
                    1597984510000,
                    1597984520000,
                    1597984530000,
                    1597984540000,
                    1597984550000,
                    1597984560000,
                    1597984570000,
                    1597984580000,
                    1597984590000,
                    1597984600000,
                    1597984610000,
                    1597984620000,
                    1597984630000,
                    1597984640000,
                    1597984650000
                ],
                [
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0,
                    0.0
                ]
            ],
            "name": "throughput.read",
            "unit": "bytes"
        }
    ]
}
Signed-off-by: Naval Patel <naval.patel@seagate.com>