### PR TITLE
Filter out temporary access keys

### DIFF
--- a/csm/core/services/sessions.py
+++ b/csm/core/services/sessions.py
@@ -290,6 +290,17 @@ class LoginService:
 
         return session
 
+    async def get_temp_access_keys(self, user_id: str) -> list:
+        """
+        Gathers temporary S3 access keys for user's active sessions.
+        :param user_id: user ID, for S3 session the S3 user name is expected.
+        :return: List of temporary access keys.
+        """
+        sessions = await self._session_manager.get_all()
+        return [s.credentials.access_key for s in sessions
+                if s.credentials.user_id.lower() == user_id.lower() and isinstance(
+                    s.credentials, S3Credentials)]
+
     async def delete_all_sessions(self, session_id: Session.Id) -> None:
         """
         This Function will delete all the current user's active sessions.


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Temporary S3 access keys are visible to user when listing access keys.
</pre>
## Unit testing on RPM done
<pre>
Tested locally.
</pre>
## Problem Description
<pre>
Every time the user logs in using the S3 account's logging profile a temporary access key is created for session.
If user lists all access keys, temporary keys are in the list among default keys and keys created by user.
Need to hide temporary keys. 
</pre>
## Solution
<pre>
Filter out temporary keys that are available in CSM's session context.
</pre>
## Unit Test Cases
<pre>
- Perform login with the same credentials several times; list account's access keys; make sure no excess keys appeared.
</pre>