### PR TITLE
Updated messages are per review comments

### DIFF
--- a/csm/core/services/users.py
+++ b/csm/core/services/users.py
@@ -51,7 +51,7 @@ class UserManager:
         # validate the model
         existing_user = await self.get(user.user_id)
         if existing_user:
-            raise ResourceExist("Such user already exists", USERS_MSG_ALREADY_EXISTS,existing_user.user_id)
+            raise ResourceExist(f"User already exists :{existing_user.user_id}", USERS_MSG_ALREADY_EXISTS)
 
         return await self.storage(User).store(user)
 
@@ -283,7 +283,7 @@ class CsmUserService(ApplicationService):
             await self._validation_for_update_by_normal_user(user_id, loggedin_user_id, new_values)
         
         if current_password and not self._verfiy_current_password(user, current_password):
-            raise InvalidRequest("Cannot change password without valid current password",
+            raise InvalidRequest("Cannot update user details without valid current password",
                                       USERS_MSG_UPDATE_NOT_ALLOWED)
         
         user.update(new_values)


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
  <code>
  Story Ref (if any): 
    User improvements change error messages
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    In user improvement demo, suggestion for change message were given
  </code>
</pre>
## Solution
<pre>
  <code>
 New message "Cannot update user details without valid current password"
and 
"User already exists :nkpcsm4"
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Using postman
POST for duplicate user
{
    "error_code": "4103",
    "message": "User already exists :nkpcsm4",
    "message_id": "users_already_exists"
}

Patch with correct current_password
{
    "error_code": "4099",
    "message": "Cannot update user details without valid current password",
    "message_id": "update_not_allowed"
}
  </code>
</pre>

Signed-off-by: Naval Patel <naval.patel@seagate.com>