### PR TITLE
Add files for auto-stale and codeowners feature

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,12 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 4
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - feature
+# Label to use when marking an issue as stale
+staleLabel: needs-attention
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+    This issue/pull request has been marked as `needs attention` as it has been left pending without new activity for 4 days.
+    Tagging @ajaysrivas @kupranay for appropriate assignment.
+    Sorry for the delay & Thank you for contributing to CORTX. We will get back to you as soon as possible.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*      @ajaysrivas @kupranay


### PR DESCRIPTION
Signed-off-by: Gaurav Chaudhari <gaurav.chaudhari@seagate.com>

About auto-stale feature -
Adding file stale.yml to enable the auto-stale features on issues/pull requests.
As defined in the configuration, if any Issue/PR goes unattended for 4 days, it will get labeled as auto-stale.
We have tagged code owners in the stale-bot message so they will get notified for stale issues/pull requests and could assign it further to the appropriate person.
More info - https://github.com/probot/stale

About Codeowners feature -
Using the CODEOWNERS file, Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.
More info - https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners