### PR TITLE
Add workflow file to generate submodule update event

### DIFF
--- a/.github/workflows/dispatch_submodule_update.yml
+++ b/.github/workflows/dispatch_submodule_update.yml
@@ -1,7 +1,7 @@
 name: Dispatch event for cortx submodule
 on:
   push:
-    branches: [ release ]
+    branches: [ main ]
 jobs:
   dispatch:
     strategy:


### PR DESCRIPTION
Workflow to update cortx-motr submodule present in [cortx repository](https://github.com/Seagate/cortx) to the latest commits on the `release` branch of [cortx-management repository](https://github.com/Seagate/cortx-management).
This workflow would get triggered by a commit on the `release` branch and generates a dispatch event named `submodule-update-event` which would, in turn, triggers [workflow](https://github.com/Seagate/cortx/blob/master/.github/workflows/update-submodules.yml) in cortx repository and updates submodule remote to the latest commit.