### PR TITLE
EOS-12950: add S3 URL to S3 services responses

### DIFF
--- a/csm/common/service_urls.py
+++ b/csm/common/service_urls.py
@@ -16,15 +16,20 @@
 
 from typing import Union, List
 
-from csm.common.services import ApplicationService
 from csm.common.conf import Conf
 from csm.core.blogic import const
 
 
-class UrlsService(ApplicationService):
+class ServiceUrls:
+    """
+    Helper class that manages CORTX URLS.
+
+    Provides various CORTX URLs retrieved from the provisioner in a clean and user-friendly format.
+    """
+
     def __init__(self, provisioner):
         """
-        Initialize UrlsService.
+        Initialize ServiceUrls.
 
         :param provisioner: provisioner object.
         """

--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -107,13 +107,6 @@ class CsmAgent:
         CsmRestApi._app["roles_service"] = roles_service
 
 
-        # S3 Plugin creation
-        s3 = import_plugin_module(const.S3_PLUGIN).S3Plugin()
-        CsmRestApi._app[const.S3_IAM_USERS_SERVICE] = IamUsersService(s3)
-        CsmRestApi._app[const.S3_ACCOUNT_SERVICE] = S3AccountService(s3)
-        CsmRestApi._app[const.S3_BUCKET_SERVICE] = S3BucketService(s3)
-        CsmRestApi._app[const.S3_ACCESS_KEYS_SERVICE] = S3AccessKeysService(s3)
-
         #TODO : This is a temporary fix for build failure.
         # We need to figure out a better solution.
         #global base_path
@@ -140,6 +133,13 @@ class CsmAgent:
         except CsmError as ce:
             Log.error(f"Unable to load Provisioner plugin: {ce}")
 
+        # S3 Plugin creation
+        s3 = import_plugin_module(const.S3_PLUGIN).S3Plugin()
+        CsmRestApi._app[const.S3_IAM_USERS_SERVICE] = IamUsersService(s3, provisioner)
+        CsmRestApi._app[const.S3_ACCOUNT_SERVICE] = S3AccountService(s3, provisioner)
+        CsmRestApi._app[const.S3_BUCKET_SERVICE] = S3BucketService(s3, provisioner)
+        CsmRestApi._app[const.S3_ACCESS_KEYS_SERVICE] = S3AccessKeysService(s3)
+
         user_service = CsmUserService(provisioner, user_manager)
         CsmRestApi._app[const.CSM_USER_SERVICE] = user_service
         update_repo = UpdateStatusRepository(db)
@@ -161,7 +161,6 @@ class CsmAgent:
         # Plugin for Maintenance
         # TODO : Replace PcsHAFramework with hare utility
         CsmRestApi._app[const.MAINTENANCE_SERVICE] = MaintenanceAppService(PcsHAFramework(),  provisioner, db)
-        CsmRestApi._app[const.URLS_SERVICE] = UrlsService(provisioner)
 
     @staticmethod
     def _daemonize():
@@ -247,7 +246,6 @@ if __name__ == '__main__':
     from csm.core.services.audit_log import  AuditLogManager, AuditService
     from csm.core.services.file_transfer import DownloadFileManager
     from csm.core.services.firmware_update import FirmwareUpdateService
-    from csm.core.services.urls import UrlsService
     from csm.common.errors import CsmError
     from cortx.utils.security.cipher import Cipher, CipherInvalidToken
     from csm.core.services.version import ProductVersionService

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -418,7 +418,6 @@ S3_ACCOUNT_SERVICE = "s3_account_service"
 S3_IAM_USERS_SERVICE = "s3_iam_users_service"
 S3_BUCKET_SERVICE = "s3_bucket_service"
 S3_ACCESS_KEYS_SERVICE = 's3_access_keys_service'
-URLS_SERVICE = 'urls_service'
 
 # Rsyslog
 RSYSLOG_DIR = "/etc/rsyslog.d"

--- a/csm/core/controllers/s3/accounts.py
+++ b/csm/core/controllers/s3/accounts.py
@@ -52,10 +52,9 @@ class S3AccountsListView(S3BaseView):
                   f" user_id: {self.request.session.credentials.user_id}")
         limit = self.request.rel_url.query.get("limit", None)
         marker = self.request.rel_url.query.get("continue", None)
-        urls_service = self.request.app[const.URLS_SERVICE]
         with self._guard_service():
             return await self._service.list_accounts(self.request.session.credentials,
-                                                     urls_service, marker, limit)
+                                                     marker, limit)
 
     """
     POST REST implementation for S3 account fetch request

--- a/csm/core/controllers/s3/buckets.py
+++ b/csm/core/controllers/s3/buckets.py
@@ -16,7 +16,6 @@
 import json
 from marshmallow import Schema, fields, validate
 from marshmallow.exceptions import ValidationError
-from csm.core.blogic import const
 from csm.core.controllers.validators import BucketNameValidator
 from csm.common.permission_names import Resource, Action
 from csm.core.controllers.view import CsmView, CsmAuth
@@ -55,9 +54,8 @@ class S3BucketListView(S3AuthenticatedView):
         Log.debug(f"Handling list s3 buckets fetch request."
                   f" user_id: {self.request.session.credentials.user_id}")
         # TODO: in future we can add some parameters for pagination
-        urls_service = self.request.app[const.URLS_SERVICE]
         with self._guard_service():
-            return await self._service.list_buckets(self._s3_session, urls_service)
+            return await self._service.list_buckets(self._s3_session)
 
     @CsmAuth.permissions({Resource.S3BUCKETS: {Action.CREATE}})
     async def post(self):
@@ -76,11 +74,9 @@ class S3BucketListView(S3AuthenticatedView):
         except ValidationError as val_err:
             raise InvalidRequest(f"Invalid request body: {val_err}")
 
-        urls_service = self.request.app[const.URLS_SERVICE]
         with self._guard_service():
             # NOTE: body is empty
-            result = await self._service.create_bucket(self._s3_session, urls_service,
-                                                       **bucket_creation_body)
+            result = await self._service.create_bucket(self._s3_session, **bucket_creation_body)
             return result
 
 

--- a/csm/core/controllers/s3/iam_users.py
+++ b/csm/core/controllers/s3/iam_users.py
@@ -18,7 +18,6 @@ from typing import Dict
 from marshmallow import (Schema, fields, ValidationError, validates_schema)
 from csm.common.errors import InvalidRequest
 from csm.common.permission_names import Resource, Action
-from csm.core.blogic import const
 from csm.core.controllers.validators import (PathPrefixValidator,
                                              PasswordValidator,
                                              UserNameValidator)
@@ -81,9 +80,8 @@ class IamUserListView(S3AuthenticatedView):
         Log.debug(f"Handling list IAM USER get request. "
                   f"user_id: {self.request.session.credentials.user_id}")
         # Execute List User Task
-        urls_service = self.request.app[const.URLS_SERVICE]
         with self._guard_service():
-            return await self._service.list_users(self._s3_session, urls_service)
+            return await self._service.list_users(self._s3_session)
 
     @CsmAuth.permissions({Resource.S3IAMUSERS: {Action.CREATE}})
     async def post(self):

--- a/csm/core/services/s3/buckets.py
+++ b/csm/core/services/s3/buckets.py
@@ -19,13 +19,12 @@ from botocore.exceptions import ClientError
 from boto.s3.bucket import Bucket
 
 from cortx.utils.log import Log
-from csm.common.services import ApplicationService
+from csm.common.service_urls import ServiceUrls
 
 from csm.plugins.eos.s3 import S3Plugin, S3Client
 from csm.core.providers.providers import Response
 from csm.core.services.sessions import S3Credentials
 from csm.core.services.s3.utils import S3BaseService, CsmS3ConfigurationFactory
-from csm.core.services.urls import UrlsService
 
 
 # TODO: the access to this service must be restricted to CSM users only (?)
@@ -34,9 +33,10 @@ class S3BucketService(S3BaseService):
     Service for S3 account management
     """
 
-    def __init__(self, s3plugin: S3Plugin):
+    def __init__(self, s3plugin: S3Plugin, provisioner):
         self._s3plugin = s3plugin
         self._s3_connection_config = CsmS3ConfigurationFactory.get_s3_connection_config()
+        self._provisioner = provisioner
 
     async def get_s3_client(self, s3_session: S3Credentials) -> S3Client:
         """
@@ -53,15 +53,13 @@ class S3BucketService(S3BaseService):
                                             session_token=s3_session.session_token)
 
     @Log.trace_method(Log.INFO)
-    async def create_bucket(self, s3_session: S3Credentials, urls_service: UrlsService,
+    async def create_bucket(self, s3_session: S3Credentials,
                             bucket_name: str) -> Union[Response, Bucket]:
         """
         Create new bucket by given name
 
         :param s3_session: s3 user session
         :type s3_session: S3Credentials
-        :param urls_service: service object that is able to retrieve S3 server's URL
-        :type urls_service: UrlsService
         :param bucket_name: name of bucket for creation
         :type bucket_name: str
         :return:
@@ -73,25 +71,24 @@ class S3BucketService(S3BaseService):
         except ClientError as e:
             # TODO: distinguish errors when user is not allowed to get/delete/create buckets
             self._handle_error(e)
-        bucket_url = await urls_service.get_s3_url(scheme='https', bucket_name=bucket_name)
+        service_urls = ServiceUrls(self._provisioner)
+        bucket_url = await service_urls.get_s3_url(scheme='https', bucket_name=bucket_name)
         return {
             "bucket_name": bucket_name,
             "bucket_url": bucket_url
         }  # bucket Can be None
 
     @Log.trace_method(Log.INFO)
-    async def list_buckets(self, s3_session: S3Credentials, urls_service: UrlsService) -> dict:
+    async def list_buckets(self, s3_session: S3Credentials) -> dict:
         """
         Retrieve the full list of existing buckets
 
         :param s3_session: s3 user session
         :type s3_session: S3Credentials
-        :param urls_service: service object that is able to retrieve S3 server's URL
-        :type urls_service: UrlsService
         :return:
         """
         # TODO: pagination can be added later
-        Log.debug(f"Retrieve the whole list of buckets for active user session")
+        Log.debug("Retrieve the whole list of buckets for active user session")
         s3_client = await self.get_s3_client(s3_session)  # type: S3Client
         try:
             bucket_list = await s3_client.get_all_buckets()
@@ -99,11 +96,13 @@ class S3BucketService(S3BaseService):
             # TODO: distinguish errors when user is not allowed to get/delete/create buckets
             self._handle_error(e)
 
+        service_urls = ServiceUrls(self._provisioner)
         # TODO: create model for response
         bucket_list = [
             {
                 "name": bucket.name,
-                "bucket_url": await urls_service.get_s3_url(scheme='https', bucket_name=bucket.name)
+                "bucket_url": await service_urls.get_s3_url(scheme='https',
+                                                            bucket_name=bucket.name)
             }
             for bucket in bucket_list]
         return {"buckets": bucket_list}


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
https://jts.seagate.com/browse/EOS-12950
S3 Account page should show the S3 URL
</pre>
## Unit testing on RPM done
<pre>
Tested manually.
</pre>
## Problem Description
<pre>
Refer to the JIRA ticket for more information.
</pre>
## Solution
<pre>
Introduce a helper service to retrieve S3 URL from the provisioner. Share the service between S3 services. Update the responses accordingly.
</pre>
## Unit Test Cases
<pre>
- call GET /api/v1/s3_accounts - check 's3_url' in response,
- call GET /api/v1/iam_users - check 's3_url' in response,
- call GET /api/v1/s3/bucket - check 'bucket_url' for each bucket in response,
- call POST /api/v1/s3/bucket - check 'bucket_url' in response.
</pre>