### PR TITLE
EOS-13184 Fixing Alerts -d Running Blank without values

### DIFF
--- a/csm/cli/schema/alerts.json
+++ b/csm/cli/schema/alerts.json
@@ -11,7 +11,7 @@
         {
           "flag": "-d",
           "dest": "duration",
-          "nargs": "?",
+          "nargs": "+",
           "type": "str",
           "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively",
           "default": "60s",
@@ -20,7 +20,7 @@
         {
           "flag": "-l",
           "dest": "limit",
-          "nargs": "?",
+          "nargs": "+",
           "type": "int",
           "help": "No. of Alerts",
           "default": "1000",
@@ -94,7 +94,7 @@
         {
           "flag": "-d",
           "dest": "duration",
-          "nargs": "?",
+          "nargs": "+",
           "type": "str",
           "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively",
           "default": "60s",
@@ -103,7 +103,7 @@
         {
           "flag": "-l",
           "dest": "limit",
-          "nargs": "?",
+          "nargs": "+",
           "type": "int",
           "help": "No. of Alerts",
           "default": "1000",
@@ -112,7 +112,7 @@
         {
           "flag": "-s",
           "dest": "start_date",
-          "nargs": "?",
+          "nargs": "+",
           "type": "str",
           "help": "Start date for fetching alerts.",
           "default": "",
@@ -121,7 +121,7 @@
         {
           "flag": "-e",
           "dest": "end_date",
-          "nargs": "?",
+          "nargs": "+",
           "type": "str",
           "help": "End date for fetching alerts.",
           "default": "",
@@ -130,7 +130,7 @@
         {
           "flag": "-i",
           "dest": "sensor_info",
-          "nargs": "?",
+          "nargs": "+",
           "type": "str",
           "help": "Sensor info of the resource.",
           "default": "",


### PR DESCRIPTION
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any):EOS-13184
roper error message should be shown for "alerts show" command when -d parameter is missing or wrong param along with help text update
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    This is happening since nargs parameter for accepting additional values in optional parameters is set to "?" which means that either 0 or multiple values will be expected for the optional parameter. 
Hence as a result the duration was not sent in API which was in turn returning all alerts.
Same issue found with limits, start_date and end_date values. Will be fixing those as well.
  </code>
</pre>
## Solution
<pre>
  <code>
  Replaced "?" with "+" to fix the above error.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
  Locally Tested.
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    Not required since no change in help section.
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
    cortxcli$ alerts -h
usage: cortxcli alerts [-h] {show,history,acknowledge,comment} ...

positional arguments:
  {show,history,acknowledge,comment}
    show                Displays Alerts On the cli
    history             Displays alerts history on cli
    acknowledge         Acknowledged all the alerts
    comment             Display/Add comment for an alert.

optional arguments:
  -h, --help            show this help message and exit
cortxcli$ alerts show -h
usage: cortxcli alerts show [-h] [-d DURATION [DURATION ...]] [-l [LIMIT]]
                            [-s] [-a] [-f {table,xml,json}]

optional arguments:
  -h, --help            show this help message and exit
  -d DURATION [DURATION ...]
                        Time period, for which we request alerts. Format: <x>s
                        <y>m <z>h <q>d. Where x, y, z, q is amounts of
                        seconds, minutes, hours, days respectively
  -l [LIMIT]            No. of Alerts
  -s                    Display All Alerts
  -a                    Display Active Alerts
  -f {table,xml,json}   Format of Output

  </code>
</pre>
## CLI Command Output
<pre>
  <code>
    cortxcli$ alerts show -d 200 d
error(400): Error:- Invalid Parameter for Duration
cortxcli$ alerts show -d 200d
+--------------------------------------------+--------+-------------+--------------------------------------------------------------------  -------------------------------------------------------------------+----------+----------------+--------------+----------+
|                  Alert Id                  | Health | Description |                                                                Rema  rks                                                                | Severity |     State      | Acknowledged | Resolved |
+--------------------------------------------+--------+-------------+--------------------------------------------------------------------  -------------------------------------------------------------------+----------+----------------+--------------+----------+
| 15994798249f8c8c424f79483c9fbea09cbf73a8cb |        |             |                                                                                                                                         | warning  | fault_resolved |    False     |   True   |
| 159920039419109aaa2b9246a3966bb6a9c2402a3e |        |             | Please contact Seagate Support. Visit https://www.seagate.com/suppo  rt/contact-support/ for details on how to contact Seagate Support. | warning  |     fault      |    False     |  False   |
| 159920034265f81ec7d3c146738b912e2ee1929789 |        |             | Please contact Seagate Support. Visit https://www.seagate.com/suppo  rt/contact-support/ for details on how to contact Seagate Support. | critical |    missing     |    False     |  False   |
| 159920023887127b57504647ee802ec2c0f062d482 |        |             | Please contact Seagate Support. Visit https://www.seagate.com/suppo  rt/contact-support/ for details on how to contact Seagate Support. | critical |    missing     |    False     |  False   |
+--------------------------------------------+--------+-------------+--------------------------------------------------------------------  -------------------------------------------------------------------+----------+----------------+--------------+----------+
cortxcli$ alerts show -d
usage: cortxcli alerts show [-h] [-d DURATION [DURATION ...]] [-l [LIMIT]]
                            [-s] [-a] [-f {table,xml,json}]
Error: Argument -d: expected at least one argument

  </code>
</pre>