### PR TITLE
Fixing CSM CLI Commands to CORTXCLI Commands

### DIFF
--- a/csm/cli/command_factory.py
+++ b/csm/cli/command_factory.py
@@ -53,7 +53,7 @@ class CommandFactory(object):
         if permissions:
             # common commands both in commands and permissions key list
             commands = [command for command in commands if command in permissions.keys()]
-        parser = ArgumentParser(description='CORTXCLI commands')
+        parser = ArgumentParser(description='Cortx cli commands')
         metavar = set(commands).difference(set(const.HIDDEN_COMMANDS))
         subparsers = parser.add_subparsers(metavar=metavar)
         if argv[0] in commands:


### PR DESCRIPTION
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any):EOS-13335
    CSM CLI is shown in Help menu of cortxcli
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    In Help menu, we get "CSM CLI command"
</code>
</pre>
## Solution
<pre>
  <code>
Chenged CSM CLI to CORTXCLI commands.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    Yes
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
    [root@ssc-vm-c-0746 ~]# cortxcli
Username: Administrator
Password:

**********************************

CORTX Interactive Shell
Type -h or --help for help.

***********************************

cortxcli$ -h
usage: cortxcli [-h]
                {'system', 'alerts', 'users', 'support_bundle', 's3accounts'}
                ...

Cortx cli commands

positional arguments:
  {'system', 'alerts', 'users', 'support_bundle', 's3accounts'}

optional arguments:
  -h, --help  show this help message and exit
cortxcli$

  </code>
</pre>
## CLI Command Output
<pre>
  <code>
  [root@ssc-vm-c-0746 ~]# cortxcli
Username: Administrator
Password:

**********************************

CORTX Interactive Shell
Type -h or --help for help.

***********************************

cortxcli$ -h
usage: cortxcli [-h]
                {'system', 'alerts', 'users', 'support_bundle', 's3accounts'}
                ...

CORTXCLI commands

positional arguments:
  {'system', 'alerts', 'users', 'support_bundle', 's3accounts'}

optional arguments:
  -h, --help  show this help message and exit
cortxcli$

  </code>
</pre>Signed-off-by: Prathamesh Rodi <prathamesh.rodi@seagate.com>