### PR TITLE
[CORTX1.0] EOS-13480: Validate CORTX v1.0 + UDS v1.0.2

### DIFF
--- a/cicd/pyinstaller/requirment.txt
+++ b/cicd/pyinstaller/requirment.txt
@@ -25,3 +25,4 @@ urllib3==1.25.7
 cryptography==2.8
 python-crontab==2.5.1
 confluent-kafka==1.5.0
+netifaces==0.10.9

--- a/csm/core/controllers/usl.py
+++ b/csm/core/controllers/usl.py
@@ -58,6 +58,7 @@ class _View(CsmView):
     def __init__(self, request: web.Request) -> None:
         CsmView.__init__(self, request)
         self._service = self._request.app[const.USL_SERVICE]
+        self._s3_account_service = self._request.app[const.S3_ACCOUNT_SERVICE]
 
 
 class _SecuredView(_View):
@@ -107,7 +108,7 @@ class DeviceRegistrationView(_View):
         try:
             body = await self.request.json()
             params = MethodSchema().load(body)
-            return await self._service.post_register_device(**params)
+            return await self._service.post_register_device(self._s3_account_service, **params)
         except (JSONDecodeError, ValidationError) as e:
             desc = 'Malformed input payload'
             Log.error(f'{desc}: {e}')

--- a/csm/core/data/models/usl.py
+++ b/csm/core/data/models/usl.py
@@ -13,15 +13,53 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-from schematics.types import UUIDType, StringType, IntType
+from schematics.types import BooleanType, IPv4Type, IntType, MACAddressType, StringType, UUIDType
 from schematics.transforms import blacklist
 
 # TODO: Replace with non-offensive term when possible. An issue was sent on 08/24/2020
 # to https://github.com/schematics/schematics/issues/613 requesting this.
 
-from uuid import UUID
-
 from csm.core.blogic.models import CsmModel
+from uuid import UUID
+from typing import Optional
+
+
+class NetIface(CsmModel):
+    _id = 'macAddress'
+
+    name = StringType(required=True, min_length=1)
+    mac_address = MACAddressType(required=True, serialized_name='macAddress')
+    iface_type = StringType(required=True, serialized_name='type')
+    is_active = BooleanType(required=True, serialized_name='isActive')
+    is_loopback = BooleanType(required=True, serialized_name='isLoopback')
+    ipv4 = IPv4Type()
+    netmask = StringType()
+    broadcast = StringType()
+
+    @staticmethod
+    def instantiate(
+        name: str,
+        mac_address: str,
+        iface_type: str,
+        is_active: bool,
+        is_loopback: bool,
+        ipv4: Optional[str] = None,
+        netmask: Optional[str] = None,
+        broadcast: Optional[str] = None,
+    ) -> 'NetIface':
+        i = NetIface()
+        i.name = name
+        i.mac_address = mac_address
+        i.iface_type = iface_type
+        i.is_active = is_active
+        i.is_loopback = is_loopback
+        if ipv4 is not None:
+            i.ipv4 = ipv4
+        if netmask is not None:
+            i.netmask = netmask
+        if broadcast is not None:
+            i.broadcast = broadcast
+        return i
 
 
 class Device(CsmModel):

--- a/csm/core/services/usl.py
+++ b/csm/core/services/usl.py
@@ -49,7 +49,6 @@ from csm.core.services.usl_certificate_manager import (
     USLDomainCertificateManager, USLNativeCertificateManager, CertificateError
 )
 from cortx.utils.security.secure_storage import SecureStorage
-from csm.plugins.cortx.provisioner import ClusterIdFetchError
 from cortx.utils.security.cipher import Cipher
 
 

--- a/csm/core/services/usl.py
+++ b/csm/core/services/usl.py
@@ -156,8 +156,12 @@ class UslService(ApplicationService):
         return access_params
 
     async def _cleanup_on_lyve_pilot_registration_error(
-        self, s3_account: Dict, iam_user: IamUser, iam_user_access_key: IamUserCredentials,
-        bucket: Bucket
+        self,
+        s3_account_service: S3AccountService,
+        s3_account: Dict,
+        iam_user: IamUser,
+        iam_user_access_key: IamUserCredentials,
+        bucket: Bucket,
     ) -> None:
         Log.debug('Cleaning up Lyve Pilot resources...')
         access_key = s3_account.get('access_key')
@@ -176,7 +180,6 @@ class UslService(ApplicationService):
         Log.debug('Remove IAM user')
         await iam_client.delete_user(iam_user.user_name)
         Log.debug('Remove S3 account')
-        s3_account_service = S3AccountService(self._s3plugin)
         s3_credentials = S3Credentials(
             str(s3_account.get('account_name')),
             str(s3_account.get('access_key')),
@@ -194,6 +197,7 @@ class UslService(ApplicationService):
 
     async def _initialize_lyve_pilot_s3_resources(
         self,
+        s3_account_service: S3AccountService,
         s3_account_name: str,
         s3_account_email: str,
         s3_account_password: str,
@@ -240,7 +244,6 @@ class UslService(ApplicationService):
 
         Log.debug('Create S3 account')
         try:
-            s3_account_service = S3AccountService(self._s3plugin)
             s3_account = await s3_account_service.create_account(
                 s3_account_name, s3_account_email, s3_account_password,
             )
@@ -599,6 +602,7 @@ class UslService(ApplicationService):
 
     async def post_register_device(
         self,
+        s3_account_service: S3AccountService,
         url: str,
         pin: str,
         s3_account_name: str,
@@ -626,6 +630,7 @@ class UslService(ApplicationService):
         # Let ``_initialize_lyve_pilot_s3_resources()`` propagate its exceptions
         (lyve_pilot_s3_account, lyve_pilot_iam_user, lyve_pilot_iam_user_access_key,
          lyve_pilot_bucket) = await self._initialize_lyve_pilot_s3_resources(
+            s3_account_service,
             s3_account_name,
             s3_account_email,
             s3_account_password,
@@ -648,6 +653,7 @@ class UslService(ApplicationService):
             }
         except Exception as e:
             await self._cleanup_on_lyve_pilot_registration_error(
+                s3_account_service,
                 lyve_pilot_s3_account,
                 lyve_pilot_iam_user,
                 lyve_pilot_iam_user_access_key,
@@ -698,6 +704,7 @@ class UslService(ApplicationService):
                 }
         except Exception as e:
             await self._cleanup_on_lyve_pilot_registration_error(
+                s3_account_service,
                 lyve_pilot_s3_account,
                 lyve_pilot_iam_user,
                 lyve_pilot_iam_user_access_key,

--- a/csm/core/services/usl.py
+++ b/csm/core/services/usl.py
@@ -45,9 +45,11 @@ from csm.core.data.models.s3 import IamUser, IamUserCredentials
 from csm.core.data.models.system_config import ApplianceName
 from csm.core.data.models.usl import Device, Volume, ApiKey
 from csm.core.services.s3.utils import CsmS3ConfigurationFactory, S3ServiceError
+from csm.core.services.usl_net_ifaces import get_interface_details
 from csm.core.services.usl_certificate_manager import (
     USLDomainCertificateManager, USLNativeCertificateManager, CertificateError
 )
+from csm.plugins.cortx.provisioner import NetworkConfigFetchError
 from cortx.utils.security.secure_storage import SecureStorage
 from cortx.utils.security.cipher import Cipher
 
@@ -837,7 +839,6 @@ class UslService(ApplicationService):
             raise CsmNotFoundError(reason)
         return material
 
-    # TODO replace stub
     async def get_network_interfaces(self) -> List[Dict[str, Any]]:
         """
         Provides a list of all network interfaces in a system.
@@ -845,20 +846,17 @@ class UslService(ApplicationService):
         :return: A list containing dictionaries, each containing information about a specific
             network interface.
         """
-        return [
-            {
-                'name': 'tbd',
-                'type': 'tbd',
-                'macAddress': 'AA:BB:CC:DD:EE:FF',
-                'isActive': True,
-                'isLoopback': False,
-                'ipv4': '127.0.0.1',
-                'netmask': '255.0.0.0',
-                'broadcast': '127.255.255.255',
-                'gateway': '127.255.255.254',
-                'ipv6': '::1',
-                'link': 'tbd',
-                'duplex': 'tbd',
-                'speed': 0,
-            }
-        ]
+        try:
+            conf = await self._provisioner.get_network_configuration()
+            ip = conf.mgmt_vip
+        except NetworkConfigFetchError as e:
+            reason = 'Could not obtain network configuration from provisioner'
+            Log.error(f'{reason}: {e}')
+            raise CsmInternalError(reason) from e
+        try:
+            iface_data = get_interface_details(ip)
+        except (ValueError, RuntimeError) as e:
+            reason = f'Could not obtain interface details from address {ip}'
+            Log.error(f'{reason}: {e}')
+            raise CsmInternalError(reason) from e
+        return [iface_data.to_native()]

--- a/csm/core/services/usl_net_ifaces.py
+++ b/csm/core/services/usl_net_ifaces.py
@@ -1,0 +1,69 @@
+from ipaddress import ip_address
+from typing import Any, Dict, Optional
+from netifaces import AF_LINK, AF_INET, ifaddresses, interfaces
+
+from csm.core.data.models.usl import NetIface
+
+
+def _get_ifaddresses_items(iface: str) -> Dict[str, Any]:
+    return {
+        k: v for k, v in ifaddresses(iface).items() if k in (AF_LINK, AF_INET)
+    }
+
+
+def _search_interface_by_ipv4_addr(addr: str) -> Optional[str]:
+    for iface in interfaces():
+        details = _get_ifaddresses_items(iface)
+        for inet in details.get(AF_INET, ()):
+            if inet.get('addr') == addr:
+                return iface
+    return None
+
+
+def get_interface_details(addr: str) -> NetIface:
+    # Validate IP address
+    try:
+        ip_address(addr)
+    except ValueError as e:
+        raise ValueError('Invalid IP address') from e
+    # Initialize dict
+    args: Dict[str, Any] = dict()
+    # Fill basic info
+    alias_name = _search_interface_by_ipv4_addr(addr)
+    if alias_name is None:
+        raise RuntimeError(f'IP address {addr} is not currently assigned to an interface')
+    iface_name = next(iter(alias_name.split(':')))
+    args['name'] = iface_name
+    # Get interface details based on name
+    try:
+        alias_details = _get_ifaddresses_items(alias_name)
+        iface_details = _get_ifaddresses_items(iface_name)
+    except ValueError as e:
+        raise RuntimeError(f'Could not obtain interface details for address {addr}') from e
+    # Fill link info
+    # FIXME derive ``isActive``, ``isLoopback``, ``type`` from link info
+    args['is_active'] = True
+    args['is_loopback'] = ip_address(addr).is_loopback
+    args['iface_type'] = 'loopback' if args['is_loopback'] else 'ether'
+    if (
+        AF_LINK in iface_details and
+        len(iface_details[AF_LINK]) > 0 and
+        'addr' in iface_details[AF_LINK][0]
+    ):
+        args['mac_address'] = iface_details[AF_LINK][0]['addr']
+    # Fill inet info
+    for inet in alias_details.get(AF_INET, ()):
+        if inet.get('addr') != addr:
+            pass
+        if 'addr' in inet:
+            args['ipv4'] = inet['addr']
+        if 'netmask' in inet:
+            args['netmask'] = inet['netmask']
+        if 'broadcast' in inet:
+            args['broadcast'] = inet['broadcast']
+    # Check for mandatory fields
+    try:
+        o = NetIface.instantiate(**args)
+    except TypeError as e:
+        raise ValueError(f'Could not build USL network interface model details for {addr}') from e
+    return o


### PR DESCRIPTION
This PR contains patches from two other PRs which were closed: https://github.com/Seagate/cortx-manager/pull/69 and https://github.com/Seagate/cortx-manager/pull/94 .

Besides that, it addresses one other issue: USL currently makes direct use of the S3 Account Server, which had its constructor updated recently, but USL was not updated for some reason. Now USL makes direct use of the respective CSM service app.

Description of https://github.com/Seagate/cortx-manager/pull/69 :

> # Problem Statement
> 
> [EOS-13391: Replace `GET /usl/v1/system/network/interfaces` stub in CSM/USL with correct implementation](https://jts.seagate.com/browse/EOS-13391)
> [EOS-13415: Implement: Replace `GET /usl/v1/system/network/interfaces` stub in CSM/USL with correct implementation](https://jts.seagate.com/browse/EOS-13415)
> 
> See tickets for details.
> 
> # Unit testing on RPM done
> 
> Yes.
> 
> - Tested on already configured VM with UDS v1.0.2
> - RPM package updated manually with a Jenkins build from this same PR
> - API endpoint works fine
> - UDX registration works fine
> - UDX data move could not be tested due to known issue involving `hctl status --json`---please advise on how to update `hctl` if the issue has already been fixed.
> 
> 
> # Problem Description
> 
> See tickets for details.
> 
> # Solution
> 
> - Implement USL network interface details model
> - Implement retrieval of network interface details for a specific IPv4 address
> - Replace `GET /usl/v1/system/network/interfaces` return stub by actual information on the cluster interface.
> 
> # Unit Test Cases
> 
> - `GET /usl/v1/system/network/interfaces` should return actual information on the cluster interface.

Description of https://github.com/Seagate/cortx-manager/pull/94 :

> # Problem Statement
> 
> [EOS-13498: Fix REST API error response when session credentials are not available](https://jts.seagate.com/browse/EOS-13498)
> 
> See ticket for details.
> 
> # Unit testing on RPM done
> 
> Yes.
> 
> # Problem Description
> 
> See tickets for details.
> 
> # Solution
> 
> - Test if `request.session` and `request.session.credentials` are existing, non-null values.
> 
> # Test Cases
> 
> - `GET /usl/v1/system/certificates/{type}` should return status code 400 in case of a non-existing `type` (e.g., `devicePrivateKey`).

