### PR TITLE
EOS-13499 Changes for Updating Help for Roles section in CSM Update.

### DIFF
--- a/csm/cli/schema/users.json
+++ b/csm/cli/schema/users.json
@@ -107,7 +107,7 @@
         {
           "flag": "roles",
           "type": "str",
-          "help": "Select an appropriate role for the user.\n Monitor provides viewing access. Manage provides editing access. *Role Changes only allowed to User with Monitor/Admin Access.",
+          "help": "Select an appropriate role for the user.\n Monitor provides viewing access. Manage provides editing access. *Role Changes only allowed to User with Admin Access.",
           "choices": [
             "monitor",
             "manage"


### PR DESCRIPTION
Signed-off-by: Prathamesh Rodi <prathamesh.rodi@seagate.com>
# Backend

## Problem Statement
<pre>
  <code>
  Story Ref (if any): EOS-13499
Changes for Updating Help Section for CLI
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
 CSM user with monitor role has option to update its role in help section for "users update"
</code>
</pre>
## Solution
<pre>
  <code>
As per discussion with Pranay Added a note in CLI as * that roles section will only be available for Monitor and Admin Roles
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Locally Tested
  </code>
</pre>