### PR TITLE
[cortx] resolve EOS-13591 exit on login failure

### DIFF
--- a/csm/cli/csm_client.py
+++ b/csm/cli/csm_client.py
@@ -109,13 +109,13 @@ class CsmRestClient(CsmClient):
         url = "/v1/login"
         method = const.POST
         body = {"username": username, "password": password}
-        try: 
+        try:
             async with aiohttp.ClientSession() as session:
                 response, headers = await self.process_direct_request(
                     url, session, method, {}, body)
-        except CsmError as e:
+        except CsmError:
             # during login we want to logout on  any error
-            return False 
+            return False
         token = headers.get('Authorization', "").split(' ')
         if self._failed(response) and len(token) != 2 and token[0] != 'Bearer':
             return False


### PR DESCRIPTION
### CLI
## Problem Statement
<pre>
  <code>
  Story Ref (if any): EOS-13591
 Not exiting even after login failure
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
 cli continue even after login failure.
</code>
</pre>
## Solution
<pre>
  <code>
Handle parsing error, Handle CsmError in login
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Locally Tested
(csmvenv) -bash-4.2$ python csm/cli/cortxcli.py
Username: admin
Password:
Server authentication check failed.
(csmvenv) -bash-4.2


  </code>
</pre>


Signed-off-by: Naval Patel <naval.patel@seagate.com>