### PR TITLE
[main] Resolve EOS-13631 Corrected help string for support_bundle generate

### DIFF
--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -4,7 +4,7 @@
   "sub_commands": [
     {
       "name": "generate",
-      "description": "Displays Alerts On the cli",
+      "description": "Generate Support Bundle",
       "need_confirmation": false,
       "permissions_tag": "create",
       "args": [


### PR DESCRIPTION
### CLI
## Problem Statement
<pre>
  <code>
  Story Ref (if any): EOS-13631
 Incorrect help for support_bundle generate command
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
 Incorrect help for support_bundle generate command
</code>
</pre>
## Solution
<pre>
  <code>
Corrected help string for suppot_bundle generate 
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Locally Tested
  </code>
</pre>
Signed-off-by: Naval Patel <naval.patel@seagate.com>