### PR TITLE
[CORTX1.0] EOS-13625: fix audit logging of session credentials

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -151,7 +151,8 @@ class CsmRestApi(CsmApi, ABC):
             resp["message"] = f'{str(err)}'
 
         audit = CsmRestApi.http_request_to_log_string(request)
-        if hasattr(request,"session"):
+        if (getattr(request, "session", None) is not None
+                and getattr(request.session, "credentials", None) is not None):
             Log.audit(f'User: {request.session.credentials.user_id} '
                       f'{audit} RC: {resp["error_code"]}')
         else:


### PR DESCRIPTION
# Bug

## Problem Statement
<pre>
https://jts.seagate.com/browse/EOS-13625
</pre>
## Unit testing on RPM done
<pre>
Tested manually.
</pre>
## Problem Description
<pre>
Check the JIRA ticket for details.
</pre>
## Solution
<pre>
Check if session credentials object is not None when audit logging the session.
</pre>
## Unit Test Cases
<pre>
- login with IAM user credentials
</pre>