### PR TITLE
EOS-13635 Changes for Help Section In Alerts

### DIFF
--- a/csm/cli/schema/alerts.json
+++ b/csm/cli/schema/alerts.json
@@ -13,7 +13,7 @@
           "dest": "duration",
           "nargs": "+",
           "type": "str",
-          "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively. Past 60 Seconds Alerts will be Displayed if not set explicitly.",
+          "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively. Past 60 seconds alerts will be displayed if not set explicitly.",
           "default": "60s",
           "params": true
         },
@@ -22,7 +22,7 @@
           "dest": "limit",
           "nargs": "+",
           "type": "int",
-          "help": "No. of Alerts to be Displayed on Terminal. 1000 Alerts Max will be Displayed if not set explicitly.",
+          "help": "No. of Alerts to be Displayed on Terminal. 1000 Alerts will be displayed if not set explicitly.",
           "default": "1000",
           "params": true
         },
@@ -96,7 +96,7 @@
           "dest": "duration",
           "nargs": "+",
           "type": "str",
-          "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively. Past 60 Seconds Alerts will be Displayed if not set explicitly.",
+          "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively. Past 60 seconds alerts will be displayed if not set explicitly.",
           "default": "60s",
           "params": true
         },

--- a/csm/cli/schema/alerts.json
+++ b/csm/cli/schema/alerts.json
@@ -13,7 +13,7 @@
           "dest": "duration",
           "nargs": "+",
           "type": "str",
-          "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively",
+          "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively. Past 60 Seconds Alerts will be Displayed if not set explicitly.",
           "default": "60s",
           "params": true
         },
@@ -22,7 +22,7 @@
           "dest": "limit",
           "nargs": "+",
           "type": "int",
-          "help": "No. of Alerts",
+          "help": "No. of Alerts to be Displayed on Terminal. 1000 Alerts Max will be Displayed if not set explicitly.",
           "default": "1000",
           "params": true
         },
@@ -96,7 +96,7 @@
           "dest": "duration",
           "nargs": "+",
           "type": "str",
-          "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively",
+          "help": "Time period, for which we request alerts. Format: <x>s <y>m <z>h <q>d. Where x, y, z, q is amounts of seconds, minutes, hours, days respectively. Past 60 Seconds Alerts will be Displayed if not set explicitly.",
           "default": "60s",
           "params": true
         },


### PR DESCRIPTION
Signed-off-by: Prathamesh Rodi <prathamesh.rodi@seagate.com>
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any):EOS-13635
Default Value For Parameters needs to Be displayed in Alerts.

  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes/No
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Since Default Duration is 60sec There is a confusion between teams that alerts are not displayed.

  </code>
</pre>
## Solution
<pre>
  <code>
    Your Problem solution here...
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   Added Default Values in Help section
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    Yes/No
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
    cortxcli$ alerts show -h
usage: cortxcli alerts show [-h] [-d DURATION [DURATION ...]]
                            [-l LIMIT [LIMIT ...]] [-s] [-a]
                            [-f {table,xml,json}]

optional arguments:
  -h, --help            show this help message and exit
  -d DURATION [DURATION ...]
                        Time period, for which we request alerts. Format: <x>s
                        <y>m <z>h <q>d. Where x, y, z, q is amounts of
                        seconds, minutes, hours, days respectively. Past 60
                        seconds alerts will be displayed if not set
                        explicitly.
  -l LIMIT [LIMIT ...]  No. of Alerts to be displayed on Terminal. 1000 Alerts
                        Max will be Displayed if not set explicitly.
  -s                    Display All Alerts
  -a                    Display Active Alerts
  -f {table,xml,json}   Format of Output
  </code>
</pre>
## CLI Command Output
<pre>
  <code>
    cortxcli$ alerts show -h
usage: cortxcli alerts show [-h] [-d DURATION [DURATION ...]]
                            [-l LIMIT [LIMIT ...]] [-s] [-a]
                            [-f {table,xml,json}]

optional arguments:
  -h, --help            show this help message and exit
  -d DURATION [DURATION ...]
                        Time period, for which we request alerts. Format: <x>s
                        <y>m <z>h <q>d. Where x, y, z, q is amounts of
                        seconds, minutes, hours, days respectively. Past 60
                        seconds alerts will be displayed if not set
                        explicitly.
  -l LIMIT [LIMIT ...]  No. of Alerts to be displayed on Terminal. 1000 Alerts
                        Max will be Displayed if not set explicitly.
  -s                    Display All Alerts
  -a                    Display Active Alerts
  -f {table,xml,json}   Format of Output

  </code>
</pre>