### PR TITLE
EOS-12467 Changes for Support Bundle Cortx Branch

### DIFF
--- a/csm/cli/schema/bundle_generate.json
+++ b/csm/cli/schema/bundle_generate.json
@@ -20,14 +20,6 @@
       "help": "Current Node Name."
     },
     {
-      "flag": "-o",
-      "dest": "os_flag",
-      "action": "store_const",
-      "help": "Generate Only OS Logs",
-      "default": "false",
-      "const": "true"
-    },
-    {
       "flag": "-c",
       "dest": "components",
       "type": "str",

--- a/csm/cli/support_bundle/bundle_generate.py
+++ b/csm/cli/support_bundle/bundle_generate.py
@@ -21,6 +21,7 @@ from csm.common import comm
 from csm.common.payload import Yaml, Tar
 from csm.core.blogic import const
 from datetime import datetime
+from csm.common.process import SimpleProcess
 from csm.common.conf import Conf
 from cortx.utils.log import Log
 
@@ -59,17 +60,29 @@ class ComponentsBundle:
         Log.support_bundle(message)
 
     @staticmethod
-    def exc_components_cmd(commands: List, bundle_id: str, path: str):
+    def exc_components_cmd(commands: List, bundle_id: str, path: str,
+            component: str, node_name: str, comment: str):
         """
         Executes the Command for Bundle Generation of Every Component.
         :param commands: Command of the component :type:str
         :param bundle_id: Unique Bundle ID of the generation process. :type:str
         :param path: Path to create the tar by components :type:str
+        :param component: Name of Component to be executed :type: str
+        :param node_name:Name of Node where the Command is being Executed
+        :type:str
+        :param comment: :User Comment: type:str
         :return:
         """
         for command in commands:
             Log.debug(f"Executing command -> {command} {bundle_id} {path}")
-            os.system(f"{command} {bundle_id} {path}")
+            cmd_proc = SimpleProcess(f"{command} {bundle_id} {path}")
+            output, err, return_code = cmd_proc.run()
+            Log.debug(f"Command Output -> {output} {err}, {return_code}")
+            if err:
+                ComponentsBundle.publish_log(
+                    f"Bundle generation failed for {component}", ERROR,
+                    bundle_id, node_name, comment)
+
 
     @staticmethod
     def send_file(protocol_details: Dict, file_path: str):
@@ -117,12 +130,11 @@ class ComponentsBundle:
         node_name = command.options.get(const.SB_NODE_NAME, "")
         comment = command.options.get(const.SB_COMMENT, "")
         components = command.options.get(const.SB_COMPONENTS, [])
-        os_flag =  True if command.options.get("os_flag", []) == 'true' else False
         ftp_msg, file_link_msg, components_list = "", "", []
 
         Log.debug((f"{const.SB_BUNDLE_ID}: {bundle_id}, {const.SB_NODE_NAME}: {node_name}, "
                    f" {const.SB_COMMENT}: {comment}, {const.SB_COMPONENTS}: {components},"
-                   f" {const.SOS_COMP}: {os_flag}"))
+                   f" {const.SOS_COMP}"))
         # Read Commands.Yaml and Check's If It Exists.
         support_bundle_config = Yaml(const.COMMANDS_FILE).load()
         if not support_bundle_config:
@@ -143,18 +155,15 @@ class ComponentsBundle:
         # Start Execution for each Component Command.
         threads = []
         command_files_info = support_bundle_config.get("COMMANDS")
-        # OS Logs Are to be Specifically Mentioned to Be Generated.
-        # Hence here Even When All is Selected O.S. Logs Will Be Skipped.
+        # OS Logs are specifically generated hence here Even When All is Selected O.S. Logs Will Be Skipped.
         if components:
             if "all" not in components:
                 components_list = list(set(command_files_info.keys()).intersection(set(components)))
             else:
                 components_list = list(command_files_info.keys())
                 components_list.remove(const.SOS_COMP)
-        # If OS Flag is True Bundle Will Generate Only Os Logs.
-        if os_flag or const.SOS_COMP in components:
-            components_list.append(const.SOS_COMP)
-        Log.debug(f"Generating for {const.SB_COMPONENTS} {' '.join(components_list)}")
+        Log.debug(
+            f"Generating for {const.SB_COMPONENTS} {' '.join(components_list)}")
         for each_component in components_list:
             components_commands = []
             components_files = command_files_info[each_component]
@@ -163,8 +172,10 @@ class ComponentsBundle:
                 if file_data:
                     components_commands = file_data.get(const.SUPPORT_BUNDLE.lower(), [])
                 if components_commands:
-                    thread_obj = threading.Thread(ComponentsBundle.exc_components_cmd(
-                        components_commands, bundle_id, f"{bundle_path}{os.sep}"))
+                    thread_obj = threading.Thread(
+                        ComponentsBundle.exc_components_cmd(components_commands,
+                            bundle_id, f"{bundle_path}{os.sep}", each_component,
+                            node_name, comment))
                     thread_obj.start()
                     Log.debug(f"Started thread -> {thread_obj.ident}  Component -> {each_component}")
                     threads.append(thread_obj)
@@ -184,22 +195,23 @@ class ComponentsBundle:
         try:
             Yaml(summary_file_path).dump(summary_data)
         except PermissionError as e:
-            ComponentsBundle.publish_log(f"Permission denied for creating summary file {e}", ERROR, bundle_id,
-                                         node_name, comment)
+            ComponentsBundle.publish_log(f"Permission denied for creating summary file {e}",
+                                         ERROR, bundle_id, node_name, comment)
             return None
         except Exception as e:
-            ComponentsBundle.publish_log(f"{e}", ERROR, bundle_id, node_name, comment)
+            ComponentsBundle.publish_log(f"{e}", ERROR, bundle_id, node_name,
+                comment)
             return None
 
         Log.debug(f'Summary file created')
         symlink_path = Conf.get(const.CSM_GLOBAL_INDEX,
-                                f"{const.SUPPORT_BUNDLE}.{const.SB_SYMLINK_PATH}")
+            f"{const.SUPPORT_BUNDLE}.{const.SB_SYMLINK_PATH}")
         if os.path.exists(symlink_path):
             try:
                 shutil.rmtree(symlink_path)
             except PermissionError:
-                Log.warn(const.PERMISSION_ERROR_MSG.format(path=symlink_path))
-        os.makedirs(symlink_path, exist_ok=True)
+                Log.warn(const.PERMISSION_ERROR_MSG.format(path = symlink_path))
+        os.makedirs(symlink_path, exist_ok = True)
 
         # Wait Until all the Threads Execution is not Complete.
         for each_thread in threads:
@@ -226,11 +238,10 @@ class ComponentsBundle:
         # Upload the File.
         try:
             uploaded = ComponentsBundle.send_file(Conf.get(const.CSM_GLOBAL_INDEX,
-                                                           const.SUPPORT_BUNDLE),
-                                                  tar_file_name)
+                                        const.SUPPORT_BUNDLE), tar_file_name)
             if uploaded:
-                 ComponentsBundle.publish_log("Uploaded on configured location.", INFO, bundle_id, node_name,
-                                         comment)
+                 ComponentsBundle.publish_log("Uploaded on configured location.",
+                                      INFO, bundle_id, node_name, comment)
         except Exception as e:
             ComponentsBundle.publish_log(f"{e}", ERROR, bundle_id, node_name,
                                          comment)

--- a/csm/cli/support_bundle/support_bundle.py
+++ b/csm/cli/support_bundle/support_bundle.py
@@ -17,21 +17,15 @@ import sys
 import os
 import string
 import random
-import asyncio
-import shutil
 import errno
-import getpass
-from threading import Thread
+from importlib import import_module
 from csm.common.payload import Yaml, JsonMessage
 from csm.core.blogic import const
-from csm.common.comm import SSHChannel
 from csm.core.services.support_bundle import SupportBundleRepository
+from csm.common.errors import (CSM_OPERATION_SUCESSFUL, CsmError,
+                            InvalidRequest, CSM_ERR_INVALID_VALUE)
 from cortx.utils.data.db.db_provider import (DataBaseProvider, GeneralConfig)
 from csm.core.providers.providers import Response
-from csm.common.errors import CSM_OPERATION_SUCESSFUL
-from csm.common.errors import CsmError
-from csm.core.providers.providers import Response
-from csm.common import errors
 from csm.common.conf import Conf
 from cortx.utils.log import Log
 import time
@@ -43,48 +37,23 @@ class SupportBundle:
     """
 
     @staticmethod
-    def execute_ssh(ip_address: str, current_user: str, ssh_key: str,
-                    command: str, node_name: str):
-        """
-        This Method makes Connection on each node and Executes Bundle Generation Command.
-        For Using this Method Need to setup ssh keys in ~/.ssh/ folder.
-
-        Please use the Following commands to do so.
-
-        $ssh-keygen
-        $ ssh-copy-id ./id_rsa.pub <username>@<host>
-
-        Once Implemented the code will be able to connect to the node.
-
-        :param ip_address: Ip Address of the Node. :type: str
-        :param bundle_id: Unique ID of the Bundle needed to be generated. :type: str
-        :param comment: Reason to generate the SB. :type: str
-        :param node_name: Name of the NODE in CORTX Term :type: str
-        :param current_user : Local User Name for SSH :type str
-        :param ssh_key: SSH Key Path :type str.
-        :return:
-        """
+    def import_provisioner_plugin():
+        """Import Plugin for Provisioner."""
         try:
-            ssh_conn_object = SSHChannel(ip_address, user=current_user,
-                                         key_filename=ssh_key)
-            ssh_conn_object.connect()
-
-            try:
-                # Executes Shell Script to Run in Background.
-                # Time out releases the connection rather than waiting for cmd.
-                # Since Shell Runs in Background no response is expected from Shell Command.
-                Log.debug(f"Executing command {command} -n {node_name} &")
-                ssh_conn_object.execute(f"{command} -n {node_name} &", timeout=120)
-            except CsmError:
-                Log.debug(f"Started bundle generation on {ip_address}")
-            ssh_conn_object.disconnect()
-        except CsmError:
-            sys.stderr.write(f"Could not connect to {ip_address}\n")
+            params = {"username": const.NON_ROOT_USER,
+                      "password": const.NON_ROOT_USER_PASS}
+            provisioner = import_module(
+                f"csm.plugins.{const.PLUGIN_DIR}.{const.PROVISIONER_PLUGIN}").ProvisionerPlugin(
+                **params)
+        except ImportError as e:
+            Log.error(f"Provisioner package not installed on system. {e}")
+            return None
+        return provisioner
 
     @staticmethod
     async def fetch_host_from_salt():
         """
-        This Method Fetchs Hostname for all nodes from Salt DB
+        This method fetch hostname for all nodes from Salt DB
         :return: hostnames : List of Hostname :type: List
         :return: node_list : : List of Node Name :type: List
         """
@@ -128,75 +97,84 @@ class SupportBundle:
             response_msg = {
                 "message": "No active nodes found. Cluster file may not be valid"}
             return Response(output=response_msg,
-                            rc=errors.CSM_ERR_INVALID_VALUE), None
+                            rc=CSM_ERR_INVALID_VALUE), None
         hostnames = []
         for each_node in active_nodes:
             hostnames.append(cluster_info.get(each_node, {}).get("hostname"))
         return hostnames, active_nodes
 
+    @staticmethod
+    def generate_bundle_id():
+        """Generate Unique Bundle ID."""
+        alphabet = string.ascii_lowercase + string.digits
+        return f"SB{''.join(random.choices(alphabet, k = 8))}"
+
+    @staticmethod
+    def get_components(components):
+        """Get Components to Generate Support Bundle."""
+        if components and "all" not in components:
+            Log.info(f"Generating bundle for  {' '.join(components)}")
+            shell_args = f"{' '.join(components)}"
+        else:
+            Log.info("Generating bundle for all CORTX components.")
+            shell_args = "all"
+        return f" -c {shell_args}"
 
     @staticmethod
     async def bundle_generate(command) -> sys.stdout:
         """
         Initializes the process for Generating Support Bundle on Each CORTX Node.
         :param command: Csm_cli Command Object :type: command
-        :return: None
+        :return: None.
         """
-        current_user = str(getpass.getuser())
-        # Check if User is Root User.
-        if current_user.lower() != const.SSH_USER_NAME:
-            repsonse_msg = f"Support Bundle {const.ROOT_PRIVILEGES_MSG}"
-            return Response(rc=errno.EACCES, output=repsonse_msg)
-        # Generate Unique Bundle ID
-        alphabet = string.ascii_lowercase + string.digits
-        bundle_id = f"SB{''.join(random.choices(alphabet, k=8))}"
+        bundle_id = SupportBundle.generate_bundle_id()
+        provisioner = SupportBundle.import_provisioner_plugin()
+        if not provisioner:
+            return Response(output = "Provisioner package not found.",
+                            rc = str(errno.ENOENT))
         # Get Arguments From Command
         comment = command.options.get(const.SB_COMMENT)
-        components = command.options.get(const.SB_COMPONENTS, [])
-        sos = True if command.options.get(const.SOS_COMP, False) == "true" else False
-        # Create Shell Command.
-        shell_args = f"-i {bundle_id} -m {repr(comment)} "
-        if sos:
-            Log.debug("Generating OS logs.")
-            shell_args = f"{shell_args} -s"
-        if components:
-            if "all" not in components:
-                Log.info(f"Generating bundle for  {' '.join(components)}")
-                shell_args = f"{shell_args} -c {' '.join(components)}"
-            else:
-                Log.info(f"Generating bundle for all CORTX components.")
-                shell_args = f"{shell_args} -c all"
-        if not components and not sos:
-            Log.info("Generating complete support bundle for SOS and components logs.")
-            shell_args = f"{shell_args} -c all -s"
+        components = command.options.get(const.SB_COMPONENTS)
+        if not components:
+            components = []
+        if command.options.get(const.SOS_COMP, False) == "true":
+            components.append("os")
+        comp_list = SupportBundle.get_components(components)
+
         # Get HostNames and Node Names.
         hostnames, node_list = await SupportBundle.fetch_host_from_salt()
         if not hostnames or not node_list:
             hostnames, node_list = await SupportBundle.fetch_host_from_cluster()
         if not isinstance(hostnames, list):
             return hostnames
-        #GET SSH KEY for Root User
-        ssh_key = os.path.expanduser(os.path.join("~", const.SSH_DIR, const.SSH_KEY))
-        Log.debug(f"Current User > {current_user}, ssh key > {ssh_key}")
-        # Start Daemon Threads for Starting SB Generation on all Nodes.
+
+        # Start SB Generation on all Nodes.
         for index, hostname in enumerate(hostnames):
             Log.debug(f"Connect to {hostname}")
-            # Add Node Name to Shell Command
-            shell_command = const.SUPPORT_BUNDLE_SHELL_COMMAND.format(
-                args=shell_args, csm_path=const.CSM_PATH)
-            thread_obj = Thread(SupportBundle.execute_ssh(hostname,
-                                                          current_user, ssh_key,
-                                                          shell_command, node_list[index]),
-                                daemon=True)
-            thread_obj.start()
+            try:
+                await provisioner.begin_bundle_generation(
+                    f"bundle_generate '{bundle_id}' '{comment}' "
+                    f"'{hostname}' {comp_list}", node_list[index])
+            except InvalidRequest:
+                return Response(output = "Bundle generation failed.\nPlease "
+                         "check CLI for details.", rc = str(errno.ENOENT))
+            except Exception as e:
+                Log.error(f"Provisioner API call failed : {e}")
+                return Response(output = "Bundle Generation Failed.",
+                                rc = str(errno.ENOENT))
+
         symlink_path = Conf.get(const.CSM_GLOBAL_INDEX,
                                 f"{const.SUPPORT_BUNDLE}.{const.SB_SYMLINK_PATH}")
+        display_string_len = len(bundle_id) + 4
         response_msg = (
             f"Please use the below bundle id for checking the status of support bundle."
-            f" \n{bundle_id}"
+            f"\n{'-' * display_string_len}"
+            f"\n| {bundle_id} |"
+            f"\n{'-' * display_string_len}"
             f"\nPlease Find the file on -> {symlink_path} .\n")
 
-        return Response(output=response_msg, rc=errors.CSM_OPERATION_SUCESSFUL)
+        return Response(output = response_msg,
+                        rc =CSM_OPERATION_SUCESSFUL)
 
     @staticmethod
     async def bundle_status(command):
@@ -205,14 +183,14 @@ class SupportBundle:
         :param command: Csm_cli Command Object :type: command
         :return: None
         """
-        bundle_id = command.options.get("bundle_id")
+        bundle_id = command.options.get("bundle_id", "")
         conf = GeneralConfig(Yaml(const.DATABASE_CONF).load())
         db = DataBaseProvider(conf)
         repo = SupportBundleRepository(db)
         all_nodes_status = await repo.retrieve_all(bundle_id)
-        response = {"status": [each_status.to_primitive()
-                               for each_status in all_nodes_status]}
-        return Response(output=response, rc=errors.CSM_OPERATION_SUCESSFUL)
+        response = {"status": [each_status.to_primitive() for each_status in
+                               all_nodes_status]}
+        return Response(output = response, rc = CSM_OPERATION_SUCESSFUL)
 
     @staticmethod
     async def fetch_ftp_data(ftp_details):
@@ -227,7 +205,8 @@ class SupportBundle:
         try:
             ftp_details[const.PORT] = int(input("Input FTP Port:  "))
         except ValueError:
-            raise CsmError(errno.EINVAL, f"{const.PORT} must be a integer type.")
+            raise CsmError(rc = errno.EINVAL,
+                           desc = f"{const.PORT} must be a integer type.")
         ftp_details[const.USER] = str(input("Input FTP User: "))
         ftp_details[const.PASS] = str(input("Input FTP Password: "))
         ftp_details['remote_file'] = str(input("Input FTP Remote File Path: "))
@@ -243,7 +222,8 @@ class SupportBundle:
         csm_conf_file_name = os.path.join(const.CSM_CONF_PATH,
                                           const.CSM_CONF_FILE_NAME)
         if not os.path.exists(csm_conf_file_name):
-            raise CsmError(rc=errno.ENOENT, output="Config file is not exist")
+            raise CsmError(rc = errno.ENOENT,
+                           desc = "Config file does not exist.")
         conf_file_data = Yaml(csm_conf_file_name).load()
         ftp_details = conf_file_data.get(const.SUPPORT_BUNDLE)
         ftp_details = await SupportBundle.fetch_ftp_data(ftp_details)
@@ -257,17 +237,17 @@ class SupportBundle:
         for hostname in hostnames:
             process = SimpleProcess(
                 f"scp {csm_conf_file_name}  {hostname}:{csm_conf_file_name}")
-            stdout, stderr, rc = process.run()
+            process.run()
 
     @staticmethod
     async def show_config(command):
         """
         Display Config for Current FTP.
-        # Todo: Need to change this command to display the FTP Configuration
-        # for individual node.
+        # Todo: Need to change this command to display the FTP configuration for an individual node.
         :param command: Csm_cli Command Object :type: command
         :return:
         """
         support_bundle_config = Conf.get(const.CSM_GLOBAL_INDEX,
                                          const.SUPPORT_BUNDLE)
-        return Response(output=support_bundle_config, rc=CSM_OPERATION_SUCESSFUL)
+        return Response(output = support_bundle_config,
+                        rc = CSM_OPERATION_SUCESSFUL)

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -552,6 +552,7 @@ ALERT_RETRY_COUNT = 3
 COMMON = "common"
 
 SUPPORT_BUNDLE_SHELL_COMMAND = "sh {csm_path}/cli/schema/create_support_bundle.sh {args}"
+CORTXCLI = "cortxcli"
 RMQ_CLUSTER_STATUS_RETRY_COUNT = 3
 SUPPORT_MSG = "Please contact CORTX community. Visit https://github.com/Seagate/cortx for details on how to contact CORTX community."
 ID = "id"

--- a/csm/plugins/cortx/provisioner.py
+++ b/csm/plugins/cortx/provisioner.py
@@ -439,3 +439,24 @@ class ProvisionerPlugin:
         except AttributeError as error:
             Log.critical(f"{error}")
             raise PackageValidationError("Node replacement is not implemented by provisioner.")
+
+    async def begin_bundle_generation(self, command_args, target_node_id):
+        """
+        Execute Bundle Generation via Salt Script.
+        :param command_args: Arguments to be parsed to Bundle Generate Command. :type: String
+        :param target_node_id: Node_id for target node intended. :type: String
+        :return:
+        """
+        if not self.provisioner:
+            raise PackageValidationError(const.PROVISIONER_PACKAGE_NOT_INIT)
+        try:
+            Log.debug(f"Invoking Provisioner command run with "
+                      f"arguments --> cmd_name={const.CORTXCLI} "
+                      f"cmd_args={repr(command_args)} "
+                      f"targets={target_node_id}")
+            return self.provisioner.cmd_run(cmd_name=const.CORTXCLI,
+                cmd_args=str(command_args), targets=target_node_id,
+                                            nowait=True)
+        except self.provisioner.errors.ProvisionerError as e:
+            Log.error(f"Command Execution error: {e}")
+            raise PackageValidationError(f"Command Execution error: {e}")


### PR DESCRIPTION
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any):EOS-12467
    Update Support Bundle to Run without Root Access.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
Partial Testing is Done Need to Check the Final Implementation once nowait option is openned.
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Support Bundle Command only executes via root user however we need to be able to run the commands via non-root user as well.
  </code>
</pre>
## Solution
<pre>
  <code>
   Changing the SSH mechansm via Salt should remove the need for root user.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    test/support_bundle.py
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    Yes
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
    cortxcli support_bundle generate -h
usage: cortxcli support_bundle generate [-h] [--os]
                                        [-c {all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest} [{all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest} ...]]
                                        comment

positional arguments:
  comment               Specify the Reason for Generating Support Bundle.

optional arguments:
  -h, --help            show this help message and exit
  --os                  Generate Only OS Logs
  -c {all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest} [{all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest} ...]
                        Generate Bundle for Specific components defined.

  </code>
</pre>
## CLI Command Output
<pre>
  <code>
Still Testing is Pending.
  </code>
</pre>
</pre>>Signed-off-by: Prathamesh Rodi <prathamesh.rodi@seagate.com>