### PR TITLE
EOS-13727 -Cortx  Changes for Handling Import for Const in Argparse.

### DIFF
--- a/csm/cli/cortxcli.py
+++ b/csm/cli/cortxcli.py
@@ -34,6 +34,8 @@ class ArgumentError(argparse.ArgumentError):
         return f"{self.rc}: {self.message}"
 
 class Terminal:
+
+    EMPTY_PASS_FIELD = "Password field can't be empty."
     @staticmethod
     def get_quest_answer(name: str) -> bool:
         """
@@ -73,7 +75,8 @@ class Terminal:
         """
         value = value or getpass(prompt="Current Password: ")
         if not value:
-            raise ArgumentError(errno.EINVAL, f"Current {const.EMPTY_PASS_FIELD}")
+            raise ArgumentError(errno.EINVAL,
+                                f"Current {Terminal.EMPTY_PASS_FIELD}")
         return value
 
     @staticmethod
@@ -87,12 +90,12 @@ class Terminal:
                           "characters.\n"))
         value = value or getpass(prompt="Password: ")
         if not value:
-            raise ArgumentError(errno.EINVAL, const.EMPTY_PASS_FIELD)
+            raise ArgumentError(errno.EINVAL, Terminal.EMPTY_PASS_FIELD)
         if confirm_pass_flag:
             confirm_password = getpass(prompt="Confirm Password: ")
             if not confirm_password:
                 raise ArgumentError(errno.EINVAL,
-                                    f"Confirm {const.EMPTY_PASS_FIELD}")
+                                    f"Confirm {Terminal.EMPTY_PASS_FIELD}")
             if not confirm_password == value:
                 raise ArgumentError(errno.EINVAL, "Password do not match.")
         return value


### PR DESCRIPTION
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any): EOS-13727
CSM user with empty password is not working as expected.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
   Exception Is Thrown Since argparser  doesn't get cost import internally.
  </code>
</pre>
## Solution
<pre>
  <code>
    Fixed and Moved the String to Class rather than Const.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   Locally Tested with Build.
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    Yes
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
 cortxcli$ users create -h
usage: cortxcli users create [-h] username email {monitor,manage}

positional arguments:
  username          Username for user used for Login.
  email             User's valid email address.
  {monitor,manage}  Select an appropriate role for the user. Monitor provides
                    viewing access. Manage provides editing access. *Role
                    Changes only allowed to User with Admin Access.

optional arguments:
  -h, --help        show this help message and exit
  </code>
</pre>
## CLI Command Output
<pre>
  <code>
    [root@ssc-vm-c-0924 ~]# cortxcli
Username: Admin
Password:

**********************************

CORTX Interactive Shell
Type -h or --help for help.

***********************************

cortxcli$ users create -h
usage: cortxcli users create [-h] username email {monitor,manage}

positional arguments:
  username          Username for user used for Login.
  email             User's valid email address.
  {monitor,manage}  Select an appropriate role for the user. Monitor provides
                    viewing access. Manage provides editing access. *Role
                    Changes only allowed to User with Admin Access.

optional arguments:
  -h, --help        show this help message and exit
cortxcli$ users create prathamesh  prathamesh.rodi@seagate.com  monitor

Password must contain the following.
1) 1 upper and lower case character.
2) 1 numeric character.
3) 1 of the !@#$%^&*()_+-=[]{}|' characters.
Password:
usage: cortxcli users create [-h] username email {monitor,manage}
Error: 22: password field can't be empty.
cortxcli$

  </code>
</pre>