### PR TITLE
[Cortx-dev]Eos 13701: Resolved-Node names shown instead of hostname in System maintainance dropdown

### DIFF
--- a/csm/cli/schema/system.json
+++ b/csm/cli/schema/system.json
@@ -129,6 +129,7 @@
         "table": {
           "headers": {
             "name": "Node ID",
+            "hostname": "Hostname",
             "online": "Online",
             "standby": "Stand-By Status"
           },

--- a/csm/cli/schema/system.json
+++ b/csm/cli/schema/system.json
@@ -10,7 +10,7 @@
       "args": [
         {
           "flag": "resource_name",
-          "help": "Node-ID for stopping the node.",
+          "help": "Node-ID or Hostname for stopping the node.",
           "type": "str",
           "json": true
         },
@@ -40,7 +40,7 @@
       "args": [
         {
           "flag": "resource_name",
-          "help": "Provide node-id for shutting down the resource.",
+          "help": "Provide node-id or hostname for shutting down the resource.",
           "type": "str",
           "json": true
         },
@@ -70,7 +70,7 @@
       "args": [
         {
           "flag": "resource_name",
-          "help": "Node Name",
+          "help": "Node Name or Hostname of resource",
           "type": "str",
           "json": true
         },

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -460,11 +460,14 @@ class Setup:
         else:
             raise CsmSetupError("logrotate failed. %s dir missing." %const.LOGROTATE_DIR)
 
-    def _set_fqdn_for_nodeid(self):
+    @staticmethod
+    def _set_fqdn_for_nodeid():
         nodes = Setup.get_salt_data(const.PILLAR_GET, const.NODE_LIST_KEY)
+        Log.debug("Node ids obtained from salt-call:{nodes}")
         if nodes:
             for each_node in nodes:
                 hostname = Setup.get_salt_data(const.PILLAR_GET, f"{const.CLUSTER}:{each_node}:{const.HOSTNAME}")
+                Log.debug(f"Setting hostname for {each_node}:{hostname}. Default: {each_node}")
                 if hostname:
                     Conf.set(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_node}",f"{hostname}")
                 else:
@@ -756,7 +759,7 @@ class CsmSetup(Setup):
             self._rsyslog()
             self._logrotate()
             self._rsyslog_common()
-            self._set_fqdn_for_nodeid()
+            Setup._set_fqdn_for_nodeid()
             ha_check = Conf.get(const.CSM_GLOBAL_INDEX, "HA.enabled")
             if ha_check:
                 self._config_cluster(args)

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -551,7 +551,7 @@ ALERTS_SERVICE = "alerts_service"
 
 ALERT_RETRY_COUNT = 3
 COMMON = "common"
-
+MAINTENANCE = "MAINTENANCE"
 SUPPORT_BUNDLE_SHELL_COMMAND = "sh {csm_path}/cli/schema/create_support_bundle.sh {args}"
 CORTXCLI = "cortxcli"
 RMQ_CLUSTER_STATUS_RETRY_COUNT = 3

--- a/csm/core/controllers/maintenance.py
+++ b/csm/core/controllers/maintenance.py
@@ -16,6 +16,7 @@
 from .view import CsmView, CsmAuth
 from cortx.utils.log import Log
 from csm.common.errors import InvalidRequest
+from csm.common.conf import Conf
 from csm.core.blogic import const
 from csm.core.controllers.validators import Enum, ValidationErrorFormatter, Server, PortValidator
 from marshmallow import (Schema, fields, ValidationError)

--- a/csm/core/controllers/maintenance.py
+++ b/csm/core/controllers/maintenance.py
@@ -38,6 +38,8 @@ class MaintenanceView(CsmView):
     def __init__(self, request):
         super(MaintenanceView, self).__init__(request)
         self._service = self.request.app[const.MAINTENANCE_SERVICE]
+        self.hostname_nodeid_map = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
+        self.rev_hostname_nodeid_map = {host:node for node, host in self.hostname_nodeid_map.items()}
 
     @CsmAuth.permissions({Resource.SYSTEM: {Action.LIST}})
     async def get(self):
@@ -69,10 +71,8 @@ class MaintenanceView(CsmView):
         body[const.ACTION] = action
 
         #if hostname is obtained in request body then get the nodeid mapped to the hostname.
-        hostname_nodeid_map = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
-        rev_hostname_nodeid_map = {host:node for node, host in hostname_nodeid_map.items()}
-        if rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME]):
-            body[const.RESOURCE_NAME] = rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME])
+        if self.rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME]):
+            body[const.RESOURCE_NAME] = self.rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME])
         try:
             PostMaintenanceSchema().load(body,
                                          unknown=const.MARSHMALLOW_EXCLUDE)

--- a/csm/core/controllers/maintenance.py
+++ b/csm/core/controllers/maintenance.py
@@ -14,7 +14,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 from .view import CsmView, CsmAuth
-from cortx.utils.log import Log
+from eos.utils.log import Log
 from csm.common.errors import InvalidRequest
 from csm.core.blogic import const
 from csm.core.controllers.validators import Enum, ValidationErrorFormatter, Server, PortValidator
@@ -66,6 +66,12 @@ class MaintenanceView(CsmView):
         action = self.request.match_info[const.ACTION]
         body = await self.request.json()
         body[const.ACTION] = action
+
+        #if hostname is obtained in request body then get the nodeid mapped to the hostname.
+        hostname_nodeid_map = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
+        rev_hostname_nodeid_map = {v:k for k, v in hostname_nodeid_map.items()}
+        if rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME]):
+            body[const.RESOURCE_NAME] = rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME])
         try:
             PostMaintenanceSchema().load(body,
                                          unknown=const.MARSHMALLOW_EXCLUDE)

--- a/csm/core/controllers/maintenance.py
+++ b/csm/core/controllers/maintenance.py
@@ -14,7 +14,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 from .view import CsmView, CsmAuth
-from eos.utils.log import Log
+from cortx.utils.log import Log
 from csm.common.errors import InvalidRequest
 from csm.core.blogic import const
 from csm.core.controllers.validators import Enum, ValidationErrorFormatter, Server, PortValidator

--- a/csm/core/controllers/maintenance.py
+++ b/csm/core/controllers/maintenance.py
@@ -70,7 +70,7 @@ class MaintenanceView(CsmView):
 
         #if hostname is obtained in request body then get the nodeid mapped to the hostname.
         hostname_nodeid_map = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
-        rev_hostname_nodeid_map = {v:k for k, v in hostname_nodeid_map.items()}
+        rev_hostname_nodeid_map = {host:node for node, host in hostname_nodeid_map.items()}
         if rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME]):
             body[const.RESOURCE_NAME] = rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME])
         try:

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -72,8 +72,7 @@ class MaintenanceAppService(ApplicationService):
             node_info = await self._loop.run_in_executor(self._executor,
                                                 self._ha.get_nodes)
             for each_resource in node_info.get("node_status"):
-                each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", 
-                                                            each_resource[const.NAME])
+                each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])
             return node_info
         except Exception as e:
             Log.critical(f"{e}")

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -67,12 +67,16 @@ class MaintenanceAppService(ApplicationService):
         """
         Return status of cluster. List of active and passive node
         """
-        Log.debug("Get cluster status")
+        Log.info("Get cluster status")
         try:
             node_info = await self._loop.run_in_executor(self._executor,
                                                 self._ha.get_nodes)
+            Log.info(f"node_info_before: {node_info}")
             for each_resource in node_info.get("node_status"):
+                Log.info(f"Conf--->:{Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}")}")
                 each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])
+                Log.info(f"Each-resource: {each_resource}")
+            Log.info(f"node_info_after: {node_info}")
             return node_info
         except Exception as e:
             Log.critical(f"{e}")

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -73,7 +73,6 @@ class MaintenanceAppService(ApplicationService):
                                                 self._ha.get_nodes)
             Log.info(f"node_info_before: {node_info}")
             for each_resource in node_info.get("node_status"):
-                Log.info(f"COnf-> {Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])}")
                 each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])
                 Log.info(f"Each-resource: {each_resource}")
             Log.info(f"node_info_after: {node_info}")

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -73,6 +73,9 @@ class MaintenanceAppService(ApplicationService):
                                                 self._ha.get_nodes)
             Log.info(f"node_info_before: {node_info}")
             for each_resource in node_info.get("node_status"):
+                hn = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])
+                Log.info(f"hn:  {hn}")
+                Log.info(f"{const.MAINTENANCE}.{each_resource[const.NAME]}")
                 each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])
                 Log.info(f"Each-resource: {each_resource}")
             Log.info(f"node_info_after: {node_info}")

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -73,7 +73,7 @@ class MaintenanceAppService(ApplicationService):
                                                 self._ha.get_nodes)
             Log.info(f"node_info_before: {node_info}")
             for each_resource in node_info.get("node_status"):
-                Log.info(f"Conf--->:{Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}")}")
+                Log.info(f"COnf-> {Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])}")
                 each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])
                 Log.info(f"Each-resource: {each_resource}")
             Log.info(f"node_info_after: {node_info}")

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -71,14 +71,8 @@ class MaintenanceAppService(ApplicationService):
         try:
             node_info = await self._loop.run_in_executor(self._executor,
                                                 self._ha.get_nodes)
-            Log.info(f"node_info_before: {node_info}")
             for each_resource in node_info.get("node_status"):
-                hn = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])
-                Log.info(f"hn:  {hn}")
-                Log.info(f"{const.MAINTENANCE}.{each_resource[const.NAME]}")
-                each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", each_resource[const.NAME])
-                Log.info(f"Each-resource: {each_resource}")
-            Log.info(f"node_info_after: {node_info}")
+                each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}")
             return node_info
         except Exception as e:
             Log.critical(f"{e}")

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -16,7 +16,7 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict
-
+from csm.common.conf import Conf
 from cortx.utils.data.access import Query, SortBy, SortOrder
 from cortx.utils.log import Log
 from csm.common.errors import CSM_OPERATION_NOT_PERMITTED
@@ -69,8 +69,12 @@ class MaintenanceAppService(ApplicationService):
         """
         Log.debug("Get cluster status")
         try:
-            return await self._loop.run_in_executor(self._executor,
+            node_info = await self._loop.run_in_executor(self._executor,
                                                 self._ha.get_nodes)
+            for each_resource in node_info.get("node_status"):
+                each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}", 
+                                                            each_resource[const.NAME])
+            return node_info
         except Exception as e:
             Log.critical(f"{e}")
             raise CsmError(rc=CSM_INVALID_REQUEST,

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -71,8 +71,8 @@ class MaintenanceAppService(ApplicationService):
         try:
             node_info = await self._loop.run_in_executor(self._executor,
                                                 self._ha.get_nodes)
-            for each_resource in node_info.get("node_status"):
-                each_resource["hostname"] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}")
+            for each_resource in node_info.get(const.NODE_STATUS):
+                each_resource[const.HOSTNAME] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}")
             return node_info
         except Exception as e:
             Log.critical(f"{e}")


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
  <code>
  Story Ref (if any): https://jts.seagate.com/browse/EOS-13701
CSM GUI: Node names Under drop-downs on System maintenance page should display hostname /FQDN instead of srvnode1/2
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes. UI-CLI-Backend Testing done on HW sm17-r18/sm18-r18
  </code>
</pre>
## Problem Description
<pre>
  <code>
   CSM GUI and Cortxcli showing nodeid (srvnode-1/srvnode-2) instead of actual Hostname of nodes
  </code>
</pre>
## Solution
<pre>
  <code>
    Hostname corresponding to nodeid are saved to conf at the csm_setup init. And same is utilized for showing status and triggering start/stop/shutdown node.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Status
</code>
</pre>
  
![MicrosoftTeams-image](https://user-images.githubusercontent.com/66424882/94598024-f94a6e80-02ab-11eb-92e8-70dcd2a0ec12.png)
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/66424882/94598109-18490080-02ac-11eb-9a07-3050026204a6.png)
<pre>
  <code>
After triggering Shutdown Node
</code>
</pre>

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/66424882/94598170-31ea4800-02ac-11eb-835f-9a719acb3f53.png)
![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/66424882/94598291-5e05c900-02ac-11eb-9d65-fa0475f691dc.png)
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/66424882/94598293-5f36f600-02ac-11eb-8c7f-c1207805ce5e.png)

<pre>
  <code>
After triggering Start Node
</code>
</pre>

![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/66424882/94598428-90172b00-02ac-11eb-8855-2f5eb05e7c20.png)
![MicrosoftTeams-image (6)](https://user-images.githubusercontent.com/66424882/94598431-90afc180-02ac-11eb-9db0-0016a5caf3bf.png)

