### PR TITLE
[Main] EOS-13561: Handled health view changes for SASHBA

### DIFF
--- a/csm/plugins/cortx/health.py
+++ b/csm/plugins/cortx/health.py
@@ -178,17 +178,11 @@ class HealthPlugin(CsmPlugin):
                     self._prepare_resource_key(resource_schema)
             health_value = self._derive_health(message, resource_schema\
                 [const.HEALTH_ALERT_TYPE])
-            """
-            This a special case so handling seperatly.
-            """
-            if resource_type == const.SAS_RESOURCE_TYPE:
-                self._handle_sas_alert(resource_schema, health_value, extended_info)
-            else:
-                resources[const.DURABLE_ID] = info.get(const.ALERT_RESOURCE_ID, "")
-                resources[const.KEY] = resource_type + "-" + \
-                    info.get(const.ALERT_RESOURCE_ID, "")
-                resources[const.ALERT_HEALTH] = health_value
-                resource_schema[const.RESOURCE_LIST].append(resources)
+            resources[const.DURABLE_ID] = info.get(const.ALERT_RESOURCE_ID, "")
+            resources[const.KEY] = resource_type + "-" + \
+                info.get(const.ALERT_RESOURCE_ID, "")
+            resources[const.ALERT_HEALTH] = health_value
+            resource_schema[const.RESOURCE_LIST].append(resources)
         except Exception as ex:
             Log.warn(f"Parsing of health map by alert failed. {ex}")
         return resource_schema
@@ -310,23 +304,3 @@ class HealthPlugin(CsmPlugin):
         This method will call comm's stop to stop consuming from the queue.
         """
         self.comm_client.stop()
-
-    def _handle_sas_alert(self, resource_schema, health_value, extended_info):
-        """
-        This method handles the sas alert. Since, the sas alert only comes when
-        16 phy's are at fault so we need to update 16 resources at a time in
-        the health map.
-        """
-        info = extended_info.get(const.ALERT_INFO)
-        specific_info = extended_info.get(const.SPECIFIC_INFO)
-        resource_schema[const.RESOURCE_LIST] = []
-        try:
-            for items in specific_info:
-                resources = {}
-                resources[const.DURABLE_ID] = items.get(const.ALERT_RESOURCE_ID)
-                resources[const.KEY] = info.get(const.ALERT_RESOURCE_TYPE) + "-" + \
-                    items.get(const.ALERT_RESOURCE_ID)
-                resources[const.ALERT_HEALTH] = health_value
-                resource_schema[const.RESOURCE_LIST].append(resources)
-        except Exception as ex:
-            Log.warn(f"Handling SAS alert for health updation failed. {ex}")

--- a/csm/plugins/cortx/health.py
+++ b/csm/plugins/cortx/health.py
@@ -179,8 +179,7 @@ class HealthPlugin(CsmPlugin):
             health_value = self._derive_health(message, resource_schema\
                 [const.HEALTH_ALERT_TYPE])
             resources[const.DURABLE_ID] = info.get(const.ALERT_RESOURCE_ID, "")
-            resources[const.KEY] = resource_type + "-" + \
-                info.get(const.ALERT_RESOURCE_ID, "")
+            resources[const.KEY] = f"{resource_type}-{resources[const.DURABLE_ID]}"
             resources[const.ALERT_HEALTH] = health_value
             resource_schema[const.RESOURCE_LIST].append(resources)
         except Exception as ex:


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
  <code>
  Story Ref (if any): https://jts.seagate.com/browse/EOS-13561
Handle SAS port alert and health view.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
   Earlier SAS alert comes only when all the 4 ports are down. 
Now, SSPL introduced a new sas:port alert which will come when each port is down. 
Also, earlier for SASHBA health view we were having 16 phy resource info. Now it has changed to only one resource. 
  </code>
</pre>
## Solution
<pre>
  <code>
    No changes required to handle new sas:port alert. 
Due to change in SASHBA health schema we handled it in our code. 
Currently for handling SAS health there was a special code written, with this change that special code is not needed and code is more generic now.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   Locally Tested with Build.
  </code>
</pre>
