### PR TITLE
[MAIN]Eos 13701: Resolved-Node names shown instead of hostname in System maintainance dropdown

### DIFF
--- a/csm/cli/schema/system.json
+++ b/csm/cli/schema/system.json
@@ -10,7 +10,7 @@
       "args": [
         {
           "flag": "resource_name",
-          "help": "Node-ID for stopping the node.",
+          "help": "Node-ID or Hostname for stopping the node.",
           "type": "str",
           "json": true
         },
@@ -40,7 +40,7 @@
       "args": [
         {
           "flag": "resource_name",
-          "help": "Provide node-id for shutting down the resource.",
+          "help": "Provide node-id or hostname for shutting down the resource.",
           "type": "str",
           "json": true
         },
@@ -70,7 +70,7 @@
       "args": [
         {
           "flag": "resource_name",
-          "help": "Node Name",
+          "help": "Node Name or Hostname of resource",
           "type": "str",
           "json": true
         },
@@ -129,6 +129,7 @@
         "table": {
           "headers": {
             "name": "Node ID",
+            "hostname": "Hostname",
             "online": "Online",
             "standby": "Stand-By Status"
           },

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -443,6 +443,20 @@ class Setup:
         else:
             raise CsmSetupError("logrotate failed. %s dir missing." %const.LOGROTATE_DIR)
 
+    @staticmethod
+    def _set_fqdn_for_nodeid():
+        nodes = Setup.get_salt_data(const.PILLAR_GET, const.NODE_LIST_KEY)
+        Log.debug("Node ids obtained from salt-call:{nodes}")
+        if nodes:
+            for each_node in nodes:
+                hostname = Setup.get_salt_data(const.PILLAR_GET, f"{const.CLUSTER}:{each_node}:{const.HOSTNAME}")
+                Log.debug(f"Setting hostname for {each_node}:{hostname}. Default: {each_node}")
+                if hostname:
+                    Conf.set(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_node}",f"{hostname}")
+                else:
+                    Conf.set(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_node}",f"{each_node}")
+            Conf.save(const.CSM_GLOBAL_INDEX)
+
     def _set_rmq_node_id(self):
         """
         This method gets the nodes id from provisioner cli and updates
@@ -728,6 +742,7 @@ class CsmSetup(Setup):
             self._rsyslog()
             self._logrotate()
             self._rsyslog_common()
+            Setup._set_fqdn_for_nodeid()
             ha_check = Conf.get(const.CSM_GLOBAL_INDEX, "HA.enabled")
             if ha_check:
                 self._config_cluster(args)

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -244,7 +244,6 @@ class Setup:
         Setup._run_cmd("setfacl -R -b " + const.CSM_USER_HOME)
         Setup._run_cmd("setfacl -m u:" + self._user + ":rwx " + crt)
         Setup._run_cmd("setfacl -m u:" + self._user + ":rwx " + key)
-        Setup._run_cmd("chmod +x /opt/seagate/cortx/csm/scripts/cortxha_shutdown_cron.sh")
 
     def _config_user_permission_unset(self, bundle_path):
         """
@@ -422,12 +421,23 @@ class Setup:
         Configure common rsyslog and logrotate
         Also cleanup statsd
         """
-        if os.path.exists(const.LOGROTATE_DIR):
-            Setup._run_cmd("cp -f " +const.CLEANUP_LOGROTATE_PATH+ " " +const.LOGROTATE_PATH)
+        setup_info = dict()
+        try:
+            setup_info = self.get_data_from_provisioner_cli(const.GET_SETUP_INFO)
+        except ProvisionerCliError as e:
+            Log.warn(f"Salt command failed {e}")
+        if setup_info.get(const.STORAGE_TYPE) == const.STORAGE_TYPE_VIRTUAL:
+            logrotate_conf = const.CLEANUP_LOGROTATE_PATH_VIRTUAL
+            cron_conf = const.SOURCE_CRON_PATH_VIRTUAL
         else:
-            raise CsmSetupError("logrotate failed. %s dir missing." %const.LOGROTATE_DIR)
+            logrotate_conf = const.CLEANUP_LOGROTATE_PATH
+            cron_conf = const.SOURCE_CRON_PATH
+        if os.path.exists(const.LOGROTATE_DIR):
+            Setup._run_cmd("cp -f " + logrotate_conf + " " + const.CLEANUP_LOGROTATE_DEST)
+        else:
+            raise CsmSetupError("logrotate failed. %s dir missing." % const.LOGROTATE_DIR)
         if os.path.exists(const.CRON_DIR):
-            Setup._run_cmd("cp -f " +const.SOURCE_CRON_PATH+ " " +const.DEST_CRON_PATH)
+            Setup._run_cmd("cp -f " + cron_conf + " " + const.DEST_CRON_PATH)
         else:
             raise CsmSetupError("cron failed. %s dir missing." %const.CRON_DIR)
 
@@ -435,13 +445,34 @@ class Setup:
         """
         Configure logrotate
         """
+        setup_info = self.get_data_from_provisioner_cli(const.GET_SETUP_INFO)
+        if setup_info[const.STORAGE_TYPE] == const.STORAGE_TYPE_VIRTUAL:
+            source_logrotate_conf = const.SOURCE_LOGROTATE_PATH_VIRTUAL
+            cleanup_logrotate_conf = const.CLEANUP_LOGROTATE_PATH_VIRTUAL
+        else:
+            source_logrotate_conf = const.SOURCE_LOGROTATE_PATH
+            cleanup_logrotate_conf = const.CLEANUP_LOGROTATE_PATH
         if os.path.exists(const.LOGROTATE_DIR):
-            Setup._run_cmd("cp -f " +const.SOURCE_LOGROTATE_PATH+ " " +const.LOGROTATE_PATH)
-            Setup._run_cmd("cp -f " +const.CLEANUP_LOGROTATE_PATH+ " " +const.LOGROTATE_PATH)
-            Setup._run_cmd("chmod 644 " + const.LOGROTATE_PATH + "csm_agent_log.conf")
-            Setup._run_cmd("chmod 644 " + const.LOGROTATE_PATH + "cleanup_log.conf")
+            Setup._run_cmd("cp -f " + source_logrotate_conf + " " + const.SOURCE_LOGROTATE_DEST)
+            Setup._run_cmd("cp -f " + cleanup_logrotate_conf + " " + const.CLEANUP_LOGROTATE_DEST)
+            Setup._run_cmd("chmod 644 " + const.SOURCE_LOGROTATE_DEST)
+            Setup._run_cmd("chmod 644 " + const.CLEANUP_LOGROTATE_DEST)
         else:
             raise CsmSetupError("logrotate failed. %s dir missing." %const.LOGROTATE_DIR)
+
+    @staticmethod
+    def _set_fqdn_for_nodeid():
+        nodes = Setup.get_salt_data(const.PILLAR_GET, const.NODE_LIST_KEY)
+        Log.debug("Node ids obtained from salt-call:{nodes}")
+        if nodes:
+            for each_node in nodes:
+                hostname = Setup.get_salt_data(const.PILLAR_GET, f"{const.CLUSTER}:{each_node}:{const.HOSTNAME}")
+                Log.debug(f"Setting hostname for {each_node}:{hostname}. Default: {each_node}")
+                if hostname:
+                    Conf.set(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_node}",f"{hostname}")
+                else:
+                    Conf.set(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_node}",f"{each_node}")
+            Conf.save(const.CSM_GLOBAL_INDEX)
 
     def _set_rmq_node_id(self):
         """
@@ -451,9 +482,9 @@ class Setup:
         # Get get node id from provisioner cli and set to config
         node_id_data = Setup.get_data_from_provisioner_cli(const.GET_NODE_ID)
         if node_id_data:
-            Conf.set(const.CSM_GLOBAL_INDEX, f"{const.CHANNEL}.{const.NODE1}", 
+            Conf.set(const.CSM_GLOBAL_INDEX, f"{const.CHANNEL}.{const.NODE1}",
                             f"{const.NODE}{node_id_data[const.MINION_NODE1_ID]}")
-            Conf.set(const.CSM_GLOBAL_INDEX, f"{const.CHANNEL}.{const.NODE2}", 
+            Conf.set(const.CSM_GLOBAL_INDEX, f"{const.CHANNEL}.{const.NODE2}",
                             f"{const.NODE}{node_id_data[const.MINION_NODE2_ID]}")
             Conf.save(const.CSM_GLOBAL_INDEX)
         else:
@@ -483,7 +514,7 @@ class Setup:
             else:
                 raise CsmSetupError(f"Unable to fetch RMQ cluster nodes info.")
         except Exception as e:
-            
+
             raise CsmSetupError(f"Setting RMQ cluster nodes failed. {e} - {str(traceback.print_exc())}")
 
     def _set_consul_vip(self):
@@ -579,7 +610,7 @@ class Setup:
             feature_endpoints = Json(const.FEATURE_ENDPOINT_MAPPING_SCHEMA).load()
             component_list = [feature for v in feature_endpoints.values() for feature in v.get(const.DEPENDENT_ON)]
             return list(set(component_list))
-  
+
         try:
             self._setup_info  = self.get_data_from_provisioner_cli(const.GET_SETUP_INFO)
             unsupported_feature_instance = unsupported_features.UnsupportedFeaturesDB()
@@ -593,7 +624,7 @@ class Setup:
                     unsupported_features_list.append(feature.get(const.FEATURE_NAME))
 
             csm_unsupported_feature = Json(const.UNSUPPORTED_FEATURE_SCHEMA).load()
-            
+
             for setup in csm_unsupported_feature[const.SETUP_TYPES]:
                 if setup[const.NAME] == self._setup_info[const.STORAGE_TYPE]:
                     unsupported_features_list.extend(setup[const.UNSUPPORTED_FEATURES])
@@ -639,7 +670,7 @@ class Setup:
             Log.logger.debug("Updating All setup file for Auto Restart on "
                              "Failure")
             Setup._update_service_file("#< RESTART_OPTION >",
-                                      "Restart=on-failure")
+                                      "RESTART=on-failure")
             Setup._run_cmd("systemctl daemon-reload")
 
     @staticmethod
@@ -689,7 +720,7 @@ class CsmSetup(Setup):
             self._config_user()
             self.set_unsupported_feature_info()
             self._configure_system_auto_restart()
-            
+
         except Exception as e:
             raise CsmSetupError(f"csm_setup post_install failed. Error: {e} - {str(traceback.print_exc())}")
 
@@ -728,6 +759,7 @@ class CsmSetup(Setup):
             self._rsyslog()
             self._logrotate()
             self._rsyslog_common()
+            Setup._set_fqdn_for_nodeid()
             ha_check = Conf.get(const.CSM_GLOBAL_INDEX, "HA.enabled")
             if ha_check:
                 self._config_cluster(args)

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -545,7 +545,7 @@ ALERTS_SERVICE = "alerts_service"
 
 ALERT_RETRY_COUNT = 3
 COMMON = "common"
-
+MAINTENANCE = "MAINTENANCE"
 SUPPORT_BUNDLE_SHELL_COMMAND = "sh {csm_path}/cli/schema/create_support_bundle.sh {args}"
 CORTXCLI = "cortxcli"
 RMQ_CLUSTER_STATUS_RETRY_COUNT = 3

--- a/csm/core/controllers/maintenance.py
+++ b/csm/core/controllers/maintenance.py
@@ -16,6 +16,7 @@
 from .view import CsmView, CsmAuth
 from cortx.utils.log import Log
 from csm.common.errors import InvalidRequest
+from csm.common.conf import Conf
 from csm.core.blogic import const
 from csm.core.controllers.validators import Enum, ValidationErrorFormatter, Server, PortValidator
 from marshmallow import (Schema, fields, ValidationError)
@@ -66,6 +67,12 @@ class MaintenanceView(CsmView):
         action = self.request.match_info[const.ACTION]
         body = await self.request.json()
         body[const.ACTION] = action
+
+        #if hostname is obtained in request body then get the nodeid mapped to the hostname.
+        hostname_nodeid_map = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
+        rev_hostname_nodeid_map = {host:node for node, host in hostname_nodeid_map.items()}
+        if rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME]):
+            body[const.RESOURCE_NAME] = rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME])
         try:
             PostMaintenanceSchema().load(body,
                                          unknown=const.MARSHMALLOW_EXCLUDE)

--- a/csm/core/controllers/maintenance.py
+++ b/csm/core/controllers/maintenance.py
@@ -38,6 +38,8 @@ class MaintenanceView(CsmView):
     def __init__(self, request):
         super(MaintenanceView, self).__init__(request)
         self._service = self.request.app[const.MAINTENANCE_SERVICE]
+        self.hostname_nodeid_map = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
+        self.rev_hostname_nodeid_map = {host:node for node, host in self.hostname_nodeid_map.items()}
 
     @CsmAuth.permissions({Resource.SYSTEM: {Action.LIST}})
     async def get(self):
@@ -69,10 +71,8 @@ class MaintenanceView(CsmView):
         body[const.ACTION] = action
 
         #if hostname is obtained in request body then get the nodeid mapped to the hostname.
-        hostname_nodeid_map = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
-        rev_hostname_nodeid_map = {host:node for node, host in hostname_nodeid_map.items()}
-        if rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME]):
-            body[const.RESOURCE_NAME] = rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME])
+        if self.rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME]):
+            body[const.RESOURCE_NAME] = self.rev_hostname_nodeid_map.get(body[const.RESOURCE_NAME])
         try:
             PostMaintenanceSchema().load(body,
                                          unknown=const.MARSHMALLOW_EXCLUDE)

--- a/csm/core/services/maintenance.py
+++ b/csm/core/services/maintenance.py
@@ -16,7 +16,7 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict
-
+from csm.common.conf import Conf
 from cortx.utils.data.access import Query, SortBy, SortOrder
 from cortx.utils.log import Log
 from csm.common.errors import CSM_OPERATION_NOT_PERMITTED
@@ -67,10 +67,13 @@ class MaintenanceAppService(ApplicationService):
         """
         Return status of cluster. List of active and passive node
         """
-        Log.debug("Get cluster status")
+        Log.info("Get cluster status")
         try:
-            return await self._loop.run_in_executor(self._executor,
+            node_info = await self._loop.run_in_executor(self._executor,
                                                 self._ha.get_nodes)
+            for each_resource in node_info.get(const.NODE_STATUS):
+                each_resource[const.HOSTNAME] = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}.{each_resource[const.NAME]}")
+            return node_info
         except Exception as e:
             Log.critical(f"{e}")
             raise CsmError(rc=CSM_INVALID_REQUEST,


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
  <code>
  Story Ref (if any): https://jts.seagate.com/browse/EOS-13701
CSM GUI: Node names Under drop-downs on System maintenance page should display hostname /FQDN instead of srvnode1/2
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes. UI-CLI-Backend Testing done on HW sm17-r18/sm18-r18
  </code>
</pre>
## Problem Description
<pre>
  <code>
   CSM GUI and Cortxcli showing nodeid (srvnode-1/srvnode-2) instead of actual Hostname of nodes
  </code>
</pre>
## Solution
<pre>
  <code>
    Hostname corresponding to nodeid are saved to conf at the csm_setup init. And same is utilized for showing status and triggering start/stop/shutdown node.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
Status
</code>
</pre>
  
![MicrosoftTeams-image](https://user-images.githubusercontent.com/66424882/94598024-f94a6e80-02ab-11eb-92e8-70dcd2a0ec12.png)
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/66424882/94598109-18490080-02ac-11eb-9a07-3050026204a6.png)
<pre>
  <code>
After triggering Shutdown Node
</code>
</pre>

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/66424882/94598170-31ea4800-02ac-11eb-835f-9a719acb3f53.png)
![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/66424882/94598291-5e05c900-02ac-11eb-9d65-fa0475f691dc.png)
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/66424882/94598293-5f36f600-02ac-11eb-8c7f-c1207805ce5e.png)

<pre>
  <code>
After triggering Start Node
</code>
</pre>

![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/66424882/94598428-90172b00-02ac-11eb-8855-2f5eb05e7c20.png)
![MicrosoftTeams-image (6)](https://user-images.githubusercontent.com/66424882/94598431-90afc180-02ac-11eb-9db0-0016a5caf3bf.png)

