### PR TITLE
[CORTX] resolve EOS-13188 Handled KeyError in  fileparser of cli command

### DIFF
--- a/csm/cli/command.py
+++ b/csm/cli/command.py
@@ -110,6 +110,11 @@ class Validatiors:
             raise ArgumentError(errno.ENOENT,
                 ("File operation failed. "
                  "Please check if the file exists."))
+        except KeyError as err:
+            Log.error(f"Check file type. {value}: {err}")
+            raise ArgumentError(errno.ENOENT,
+                ("File operation failed. "
+                 "Please check if the file exists and its type."))
 
     @staticmethod
     def bucket_name(value):


### PR DESCRIPTION
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any):https://jts.seagate.com/browse/EOS-13188
S3 bucket policy with invalid path is not working as expected.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
   Exception KeyError Is Thrown from common payload .
  </code>
</pre>
## Solution
<pre>
  <code>
    Handled KeyError Exception in fileparser of cli command
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
   Locally Tested with Build.
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    No
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
cortxcli$ s3bucketpolicy create mybucket 89 /root/invalid_path 45
usage: cortxcli.py s3bucketpolicy create [-h]
                                         bucket_name Id Statement [Version]
Error: 2: file operation failed. please check if the file exists and its type.
cortxcli$


  </code>
</pre>
Signed-off-by: Naval Patel <naval.patel@seagate.com>