### PR TITLE
[CORTX] EOS-13870 Changed message root to Admin

### DIFF
--- a/csm/core/controllers/users.py
+++ b/csm/core/controllers/users.py
@@ -246,8 +246,8 @@ class AdminUserView(CsmView):
         if not response:
             status = const.STATUS_CONFLICT
             response = {
-                'message_id': 'root_already_exists',
-                'message_text': 'Root user already exists',
+                'message_id': 'admin_already_exists',
+                'message_text': 'Admin user already exists',
                 'extended_message': user_body['user_id']
             }
 


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
  <code>
  Story Ref (if any): https://jts.seagate.com/browse/EOS-13870
Wrong error message while trying to create existing user

  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
  Wrong error message while trying to create existing user
</code>
</pre>
## Solution
<pre>
  <code>
    Corrected message, changed Root to Admin
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
  Tested locally with POSTMAN
Output
{
    "message_id": "admin_already_exists",
    "message_text": "Admin user already exists",
    "extended_message": "Administrator"
}
  </code>
</pre>



Signed-off-by: Naval Patel <naval.patel@seagate.com>