### PR TITLE
EOS-13563 Fixing error when startup command is being executed.

### DIFF
--- a/csm/cli/scripts/system.py
+++ b/csm/cli/scripts/system.py
@@ -38,8 +38,8 @@ class System:
 
         _unstandby_cmd = const.HCTL_NODE.format(command=_command, user=_user, pwd=_password)
         subprocess_obj = AsyncioSubprocess(_unstandby_cmd)
-        _output, _err = await subprocess_obj.run()
-        if _err:
+        _output, _err, _rc = await subprocess_obj.run()
+        if _rc != 0:
             Log.error(f"_output={_output}\n _err={_err}")
             sys.stderr.write(const.HCTL_ERR_MSG)
             return

--- a/csm/common/process.py
+++ b/csm/common/process.py
@@ -76,8 +76,8 @@ class AsyncioSubprocess(Process):
                                                             stderr=asyncio.subprocess.PIPE)
             self._output, self._err = await self._process.communicate()
 
-            return self._output, self._err
+            return self._output, self._err, self._process.returncode
         except Exception as err:
             self._err = "AsyncioSubProcess Error: " + str(err)
             self._output = ""
-            return self._output, self._err
+            return self._output, self._err, self._process.returncode

--- a/csm/core/services/storage_capacity.py
+++ b/csm/core/services/storage_capacity.py
@@ -62,7 +62,7 @@ class StorageCapacityService(ApplicationService):
 
         try:
             process = AsyncioSubprocess(const.FILESYSTEM_STAT_CMD)
-            stdout, stderr = await process.run()
+            stdout, stderr, rc = await process.run()
         except Exception as e:
             raise CsmInternalError(f"Error in command execution command : {e}")
         if not stdout:


### PR DESCRIPTION
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any):EOS-13563
System Startup displays error message even when hctl command returns success.
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
System Startup displays error message even when hctl command returns success.
  </code>
</pre>
## Solution
<pre>
  <code>
Since Hctl writes multiple lines some values are captured as error. this results in errors . Replaced error check from messgaes to rc.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Locally Tested
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    Yes/No
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
    usage: cortxcli system [-h] {startup} ...

positional arguments:
  {startup}
    startup   Brings back the system after cluster has be started to original
              state.

optional arguments:
  -h, --help  show this help message and exit
  </code>
</pre>
## CLI Command Output
<pre>
  <code>
    No Changes in Output.
  </code>
</pre>