### PR TITLE
[CORTX] EOS--14059 Disabled access log for aiohttp as audit log is logging most of details

### DIFF
--- a/csm/conf/etc/csm/csm.conf
+++ b/csm/conf/etc/csm/csm.conf
@@ -112,7 +112,7 @@ Log:
     #file_size: 10
     log_path: "/var/log/seagate/csm/"
     max_result_window: 10000
-
+    usl_polling_log: false
 #CSMCLI
 CSMCLI:
     csm_agent_host: "127.0.0.1"

--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -147,7 +147,9 @@ class CsmRestApi(CsmApi, ABC):
     @staticmethod
     def process_audit_log(resp, request):
         url = request.path
-        if (not request.app["usl_polling_log"]) and url in ["/usl/v1/system"]:
+        if (not request.app["usl_polling_log"]) \
+                and ("/usl/" in url) \
+                and (url not in ["/usl/v1/registerDevice"]):
             return
         audit = CsmRestApi.http_request_to_log_string(request)
         if (getattr(request, "session", None) is not None

--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -368,7 +368,7 @@ class CsmRestApi(CsmApi, ABC):
             ssl_context = None
 
         web.run_app(CsmRestApi._app, port=port, ssl_context=ssl_context,
-                    access_log=Log.logger, access_log_format=const.REST_ACCESS_FORMAT)
+                    access_log=None, access_log_format=const.REST_ACCESS_FORMAT)
 
     @staticmethod
     async def process_request(request):

--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -143,6 +143,19 @@ class CsmRestApi(CsmApi, ABC):
         method = request.method
         user_agent = request.headers.get('User-Agent')
         return (f"Remote_IP:{remote_ip} Url:{url} Method:{method} User-Agent:{user_agent}")
+    
+    @staticmethod
+    def process_audit_log(resp, request):
+        url = request.path
+        if (not request.app["usl_polling_log"]) and url in ["/usl/v1/system"]:
+            return
+        audit = CsmRestApi.http_request_to_log_string(request)
+        if (getattr(request, "session", None) is not None
+                and getattr(request.session, "credentials", None) is not None):
+            Log.audit(f'User: {request.session.credentials.user_id} '
+                      f'{audit} RC: {resp["error_code"]}')
+        else:
+            Log.audit(f'{audit} RC: {resp["error_code"]}')
 
     @staticmethod
     def error_response(err: Exception, request) -> dict:
@@ -169,13 +182,8 @@ class CsmRestApi(CsmApi, ABC):
         else:
             resp["message"] = f'{str(err)}'
 
-        audit = CsmRestApi.http_request_to_log_string(request)
-        if (getattr(request, "session", None) is not None
-                and getattr(request.session, "credentials", None) is not None):
-            Log.audit(f'User: {request.session.credentials.user_id} '
-                      f'{audit} RC: {resp["error_code"]}')
-        else:
-            Log.audit(f'{audit} RC: {resp["error_code"]}')
+        
+        CsmRestApi.process_audit_log(resp, request)
         return resp
 
     @staticmethod

--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -63,6 +63,9 @@ class CsmAgent:
         alerts_service = AlertsAppService(alerts_repository)
         CsmRestApi.init(alerts_service)
 
+        # settting usl polling 
+        usl_polling_log = Conf.get(const.CSM_GLOBAL_INDEX, "Log.usl_polling_log")
+        CsmRestApi._app["usl_polling_log"] = usl_polling_log
         #Heath configuration
         health_repository = HealthRepository()
         health_plugin = import_plugin_module(const.HEALTH_PLUGIN)


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any):https://jts.seagate.com/browse/EOS-14059
Additional logs are generated for each REST call.
USL is polling on some api's , added configuration to disable audit logs for usl api's except '/usl/v1/registerDevice'
</pre>
## Unit testing on RPM done
<pre>
NO
</pre>
## Problem Description
<pre>
Acccess log for aiohttp is adding log for each REST call apart from audit log.
</pre>
## Solution
<pre>
Disabling aiohttp access log.
</pre>
## Unit Test Cases
<pre>
Tested on vm access logs are not log in csm_agent.log 
</pre>
Signed-off-by: Naval Patel <naval.patel@seagate.com>