### PR TITLE
[cortx1.0-dev] EOS-14074: Revert to use of cluster IP on `GET /usl/v1/system/network/interfaces`

### DIFF
--- a/csm/core/services/usl.py
+++ b/csm/core/services/usl.py
@@ -855,7 +855,7 @@ class UslService(ApplicationService):
         """
         try:
             conf = await self._provisioner.get_network_configuration()
-            ip = conf.cluster_ip
+            ip = conf.mgmt_vip
         except NetworkConfigFetchError as e:
             reason = 'Could not obtain network configuration from provisioner'
             Log.error(f'{reason}: {e}')


### PR DESCRIPTION
# Problem Statement

[EOS-13480: Validate CORTX v1.0 + UDS v1.0.2](https://jts.seagate.com/browse/EOS-13480)
[EOS-13391: Replace `GET /usl/v1/system/network/interfaces` stub in CSM/USL with correct implementation](https://jts.seagate.com/browse/EOS-13391)
[EOS-14074: Revert use of cluster IP on `GET /usl/v1/system/network/interfaces`](https://jts.seagate.com/browse/EOS-14074)

See tickets for details.

# Unit testing on RPM done

No.

# Problem Description

See tickets for details.

# Solution

- Have `GET /usl/v1/system/network/interfaces` return management VIP instead of cluster IP

# Unit Test Cases

- `GET /usl/v1/system/network/interfaces` should return actual information on the management interface