### PR TITLE
[CORTX-DEV] EOS-14145-cortx-dev: Health view changes for hostname

### DIFF
--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -603,3 +603,4 @@ EMPTY_PASS_FIELD = "Password field can't be empty."
 STORAGE_TYPE_VIRTUAL = "virtual"
 
 L18N_SCHEMA = '{}/schema/l18n.json'.format(CSM_PATH)
+SHUTDOWN_CRON_TIME = "shutdown_cron_time"

--- a/csm/core/services/health.py
+++ b/csm/core/services/health.py
@@ -58,7 +58,31 @@ class HealthAppService(ApplicationService):
         self.alerts_repo = alerts_repo
         self._is_map_updated_with_db = False
         self._health_plugin = plugin
+        self._node_hostname_map = dict()
+        self._hostname_node_map = dict()
+        self._create_node_hostname_map()
         self._init_health_schema()
+
+    def _create_node_hostname_map(self):
+        """
+        This method creates an in-memory map of minion-id to hostname and
+        vice-versa.
+        """
+        self._node_hostname_map = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}")
+        self._node_hostname_map.pop(const.SHUTDOWN_CRON_TIME)
+        self._hostname_node_map = {host:node for node, host in self._node_hostname_map.items()}
+
+    def get_minion_id(self, hostname):
+        """
+        Returns minion id for the corresponding hostname.
+        """
+        return self._hostname_node_map.get(hostname, "")
+
+    def get_hostname(self, minion_id):
+        """
+        Returns hostname for the corresponding minion id.
+        """
+        return self._node_hostname_map.get(minion_id, "")
 
     def _init_health_schema(self):
         health_schema_path = Conf.get(const.CSM_GLOBAL_INDEX,
@@ -111,6 +135,9 @@ class HealthAppService(ApplicationService):
         resources = []
         resource_details = {}
         if component_id:
+            if "node" in component_id:
+                minion_id = self.get_minion_id(component_id.split(':')[1])
+                component_id = f"node:{minion_id}"
             keys.append(component_id)
         else:
             parent_health_schema = self._get_schema(const.KEY_NODES)
@@ -158,6 +185,9 @@ class HealthAppService(ApplicationService):
             parent_health_schema = self._get_schema(const.KEY_NODES)
             keys = self._get_child_node_keys(parent_health_schema)
         for key in keys:
+            if "node" in key:
+                minion_id = self.get_minion_id(key.split(':')[1])
+                key = f"node:{minion_id}"
             node_details = await self._get_component_details(key)
             node_health_details.append(node_details)
         return node_health_details
@@ -254,6 +284,9 @@ class HealthAppService(ApplicationService):
         for component in leaf_nodes:
             component_details.append(component)
         health_summary = self._get_health_count(health_count_map, leaf_nodes)
+        if "node" in node_id:
+            hostname = self.get_hostname(node_id.split(':')[1])
+            node_id = f"node:{hostname}"
         node_details = {node_id: {const.HEALTH_SUMMARY: health_summary, "components": component_details}}
         return node_details
 
@@ -270,6 +303,9 @@ class HealthAppService(ApplicationService):
         self._get_leaf_node_health(health_schema, health_count_map,
                                    leaf_nodes, alert_uuid_map)
         health_summary = self._get_health_count(health_count_map, leaf_nodes)
+        if "node" in node_id:
+            hostname = self.get_hostname(node_id.split(':')[1])
+            node_id = f"node:{hostname}"
         node_details = {node_id: {const.HEALTH_SUMMARY: health_summary}}
         return node_details
 
@@ -485,7 +521,11 @@ class HealthAppService(ApplicationService):
             is_node_response = msg_body.get(const.NODE_RESPONSE, False)
             resource_key = msg_body.get(const.RESOURCE_KEY, "")
             sub_resource_map = self.repo.health_schema.get(resource_key)
-            node_id = "node:" + msg_body.get(const.ALERT_NODE_ID, "")
+            """
+            Converting hostname to minion id.
+            """
+            minion_id = self.get_minion_id(msg_body.get(const.ALERT_NODE_ID, ""))
+            node_id = f"node:{minion_id}"
             if is_node_response:
                 resource_map = self._get_health_schema_by_key\
                         (sub_resource_map, node_id)

--- a/csm/core/services/health.py
+++ b/csm/core/services/health.py
@@ -24,6 +24,7 @@ from csm.common.observer import Observable
 from threading import Event, Thread
 from csm.core.services.alerts import AlertRepository
 import asyncio
+from csm.common.errors import CsmError
 
 class HealthRepository:
     def __init__(self):

--- a/csm/core/services/health.py
+++ b/csm/core/services/health.py
@@ -76,13 +76,20 @@ class HealthAppService(ApplicationService):
         """
         Returns minion id for the corresponding hostname.
         """
-        return self._hostname_node_map.get(hostname, "")
+        minion_id = self._hostname_node_map.get(hostname, "")
+        if not minion_id:
+            Log.error(f"Node server id not found for {hostname}")
+            raise CsmError("Node server id not found.")
+        return minion_id
 
     def get_hostname(self, minion_id):
         """
         Returns hostname for the corresponding minion id.
         """
-        return self._node_hostname_map.get(minion_id, "")
+        hostname = self._node_hostname_map.get(minion_id, "")
+        if not hostname:
+            Log.error(f"Hostname not found for {minion_id}")
+        return hostname
 
     def _init_health_schema(self):
         health_schema_path = Conf.get(const.CSM_GLOBAL_INDEX,


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-14145
In case of health view we show UI with old hostname
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
In case of manufacturing, hostname will be different from field. Health map gets generated at time of Manufacturing which embed hostname in json file itself. This will end up showing old hostname, when hostname get changed on filed.
</pre>
## Solution
<pre>
Short term solution:--

instead of hostname use node salt id(srvnode-1, srvnode-2) instead of hostname.
CSM will map hostname to salt id and do a hack to extract srvnode details from keys.
</pre>
## Unit Test Cases
<pre>
![image](https://user-images.githubusercontent.com/66408908/95721995-fcbcfd00-0c90-11eb-98ea-7629ec5a93d2.png)

</pre>
Signed-off-by: pawan.kumarsrivastava@seagate.com
