### PR TITLE
[CORTX-DEV] Eos 14247 Improve logrotate code for CSM logs based on changes done by provisioner

### DIFF
--- a/csm/conf/etc/cron.hourly/csm_logrotate
+++ b/csm/conf/etc/cron.hourly/csm_logrotate
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-/usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/csm/logrotate/csm_agent_log.conf
-EXITVALUE=$?
-if [ $EXITVALUE != 0 ]; then
-    /usr/bin/logger -t logrotate "ALERT exited abnormally with : [$EXITVALUE]"
-fi
-exit 0

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -435,13 +435,6 @@ class Setup:
         else:
             raise CsmSetupError("cron failed. %s dir missing." %const.CRON_DIR)
 
-        if os.path.exists(const.CRON_DIR_HOURLY):
-            logrotate_conf_path = const.SOURCE_CRON_PATH_LOGROTATE
-            Setup._run_cmd("cp -f " + logrotate_conf_path + " " + const.DEST_LOGROTATE_CRON_PATH)
-            Setup._run_cmd("chmod 755 " + const.DEST_LOGROTATE_CRON_PATH)
-        else:
-            raise CsmSetupError("cron failed. %s dir missing." %const.CRON_DIR_HOURLY)
-
     def _create_cron(self):
         Log.info("Creating First Crontab.")
         os.system('echo "1 0 1 1 1  echo csm" | crontab -u csm -')
@@ -456,8 +449,6 @@ class Setup:
         else:
             source_logrotate_conf = const.SOURCE_LOGROTATE_PATH
 
-        if not os.path.exists(const.LOGROTATE_DIR_DEST):
-            Setup._run_cmd("mkdir -p " + const.LOGROTATE_DIR_DEST)
         if os.path.exists(const.LOGROTATE_DIR_DEST):
             Setup._run_cmd("cp -f " + source_logrotate_conf + " " + const.CSM_LOGROTATE_DEST)
             Setup._run_cmd("chmod 644 " + const.CSM_LOGROTATE_DEST)

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -453,7 +453,7 @@ class Setup:
             Setup._run_cmd("cp -f " + source_logrotate_conf + " " + const.CSM_LOGROTATE_DEST)
             Setup._run_cmd("chmod 644 " + const.CSM_LOGROTATE_DEST)
         else:
-            raise CsmSetupError("logrotate failed. %s dir missing." %const.LOGROTATE_DIR)
+            raise CsmSetupError("logrotate failed. %s dir missing." %const.LOGROTATE_DIR_DEST)
 
     @staticmethod
     def _set_fqdn_for_nodeid():

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -431,14 +431,9 @@ SOURCE_CRON_PATH="{0}/conf{1}/es_logrotate.cron".format(CSM_PATH, CRON_DIR)
 SOURCE_CRON_PATH_VIRTUAL="{0}/conf{1}/es_logrotate-virtual.cron".format(CSM_PATH, CRON_DIR)
 DEST_CRON_PATH="{}/es_logrotate.cron".format(CRON_DIR)
 
-
-CRON_DIR_HOURLY="/etc/cron.hourly"
-SOURCE_CRON_PATH_LOGROTATE="{0}/conf{1}/csm_logrotate".format(CSM_PATH, CRON_DIR_HOURLY)
-DEST_LOGROTATE_CRON_PATH="{}/csm_logrotate".format(CRON_DIR_HOURLY)
-
 #logrotate
 LOGROTATE_DIR = "/etc/logrotate.d"
-LOGROTATE_DIR_DEST = "/etc/csm/logrotate"
+LOGROTATE_DIR_DEST = "/etc/logrotate_hourly.d"
 
 # https status code
 STATUS_CREATED = 201


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any):https://jts.seagate.com/browse/EOS-14247
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
Privisioner has made change to invoke logrotate hourly just by adding conf file to /etc/logrotate_hourly.d/
</pre>
## Solution
<pre>
Updated csm logrotate to use provisioner changes
</pre>
## Unit Test Cases
<pre>
Logrotate triggered for csm_agent.log for more than 10mb size
</pre>
Signed-off-by: 
