### PR TITLE
[CORTX-DEV] EOS-14243-cortx-dev: Adding fru alerts to support bundle

### DIFF
--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -175,6 +175,7 @@ if [ "$COMPONENT" == "all" ] || [ "$COMPONENT" == "backend" ]; then
     cp $CONF/setup.yaml $DIST/csm/conf
     cp $CONF/uds_setup.yaml $DIST/csm/conf
     cp $CONF/elasticsearch_setup.yaml $DIST/csm/conf
+    cp $CONF/alerts_setup.yaml $DIST/csm/conf
     cp -R $CONF/etc $DIST/csm/conf
     cp -R $CONF/service/csm_agent.service $DIST/csm/conf/service
     cd $TMPDIR

--- a/csm/cli/schema/bundle_generate.json
+++ b/csm/cli/schema/bundle_generate.json
@@ -36,6 +36,7 @@
         "manifest",
         "uds",
         "elasticsearch",
+        "alerts",
         "ha"
       ],
       "nargs": "+",

--- a/csm/cli/schema/csm_bundle_generate.json
+++ b/csm/cli/schema/csm_bundle_generate.json
@@ -9,7 +9,8 @@
       "choices":[
         "csm",
         "uds",
-        "elasticsearch"
+        "elasticsearch",
+        "alerts"
       ],
       "help": "Specify the Name of component for Generating Bundle."
     },

--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -37,6 +37,7 @@
             "manifest",
             "uds",
             "elasticsearch",
+            "alerts",
             "ha"
           ],
           "nargs": "+",

--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -44,7 +44,7 @@ class CSMBundle:
         csm_log_directory_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.log_path")
         uds_log_directory_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.uds_log_path")
         elasticsearch_log_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.elasticsearch_log_path")
-        # alerts_file_path = Conf.get(const.CSM_GLOBAL_INDEX, "SUPPORT_BUNDLE.alerts_file_path")
+        alerts_filename = Conf.get(const.CSM_GLOBAL_INDEX, "SUPPORT_BUNDLE.alerts_filename")
         # Creates CSM Directory
         path = command.options.get("path")
         bundle_id = command.options.get("bundle_id")
@@ -55,11 +55,10 @@ class CSMBundle:
         if component_name == "alerts":
             # Fetch alerts for support bundle.
             alerts_data = await CSMBundle.fetch_and_save_alerts()
-            alerts_file_path = os.path.join(path, "fru_alerts.json")
+            alerts_file_path = os.path.join(path, alerts_filename)
             obj_alert_json = Json(alerts_file_path)
             obj_alert_json.dump(alerts_data)
             component_data["alerts"] = [alerts_file_path]
-            Log.info(f"alerts file patha: {alerts_file_path}") 
 
         temp_path = os.path.join(path, component_name)
         os.makedirs(temp_path, exist_ok = True)

--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -44,19 +44,23 @@ class CSMBundle:
         csm_log_directory_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.log_path")
         uds_log_directory_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.uds_log_path")
         elasticsearch_log_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.elasticsearch_log_path")
-        alerts_file_path = Conf.get(const.CSM_GLOBAL_INDEX, "SUPPORT_BUNDLE.alerts_file_path")
-        # Fetch alerts for support bundle.
-        alerts_data = await CSMBundle.fetch_and_save_alerts()
-        obj_alert_json = Json(alerts_file_path)
-        obj_alert_json.dump(alerts_data)
+        # alerts_file_path = Conf.get(const.CSM_GLOBAL_INDEX, "SUPPORT_BUNDLE.alerts_file_path")
         # Creates CSM Directory
         path = command.options.get("path")
         bundle_id = command.options.get("bundle_id")
         component_name = command.options.get("component", "csm")
         component_data = {"csm": [csm_log_directory_path],
                           "uds": [uds_log_directory_path],
-                          "elasticsearch": [elasticsearch_log_path],
-                          "alerts": [alerts_file_path]}
+                          "elasticsearch": [elasticsearch_log_path]}
+        if component_name == "alerts":
+            # Fetch alerts for support bundle.
+            alerts_data = await CSMBundle.fetch_and_save_alerts()
+            alerts_file_path = os.path.join(path, "fru_alerts.json")
+            obj_alert_json = Json(alerts_file_path)
+            obj_alert_json.dump(alerts_data)
+            component_data["alerts"] = [alerts_file_path]
+            Log.info(f"alerts file patha: {alerts_file_path}") 
+
         temp_path = os.path.join(path, component_name)
         os.makedirs(temp_path, exist_ok = True)
         # Generate Tar file for Logs Folder.

--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -16,9 +16,12 @@
 import os
 import errno
 from csm.core.blogic import const
-from csm.common.payload import Yaml, Tar
+from csm.common.payload import Yaml, Tar, Json
 from csm.common.conf import Conf
 from csm.common.errors import CsmError
+from cortx.utils.data.db.db_provider import (DataBaseProvider, GeneralConfig)
+from cortx.utils.log import Log
+from csm.core.services.alerts import AlertRepository
 
 class CSMBundle:
     """
@@ -41,13 +44,19 @@ class CSMBundle:
         csm_log_directory_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.log_path")
         uds_log_directory_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.uds_log_path")
         elasticsearch_log_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.elasticsearch_log_path")
+        alerts_file_path = Conf.get(const.CSM_GLOBAL_INDEX, "SUPPORT_BUNDLE.alerts_file_path")
+        # Fetch alerts for support bundle.
+        alerts_data = await CSMBundle.fetch_and_save_alerts()
+        obj_alert_json = Json(alerts_file_path)
+        obj_alert_json.dump(alerts_data)
         # Creates CSM Directory
         path = command.options.get("path")
         bundle_id = command.options.get("bundle_id")
         component_name = command.options.get("component", "csm")
         component_data = {"csm": [csm_log_directory_path],
                           "uds": [uds_log_directory_path],
-                          "elasticsearch": [elasticsearch_log_path]}
+                          "elasticsearch": [elasticsearch_log_path],
+                          "alerts": [alerts_file_path]}
         temp_path = os.path.join(path, component_name)
         os.makedirs(temp_path, exist_ok = True)
         # Generate Tar file for Logs Folder.
@@ -58,3 +67,19 @@ class CSMBundle:
             raise CsmError(rc = errno.ENOENT,
                            desc = f"Component log missing: {component_data[component_name]}")
 
+    @staticmethod
+    async def fetch_and_save_alerts():
+        """
+        Fetches the alerts from es db and creates a json file
+        :param command: Csm_cli Command Object :type: command
+        :return: None
+        """
+        alerts =[]
+        try:
+            conf = GeneralConfig(Yaml(const.DATABASE_CONF).load())
+            db = DataBaseProvider(conf)
+            repo = AlertRepository(db)
+            alerts = await repo.fetch_alert_for_support_bundle()
+        except Exception as ex:
+            Log.exception(f"Error occured while fetching alerts: {ex}")
+        return alerts

--- a/csm/conf/alerts_setup.yaml
+++ b/csm/conf/alerts_setup.yaml
@@ -1,0 +1,2 @@
+support_bundle:
+    - cortxcli csm_bundle_generate alerts

--- a/csm/conf/etc/csm/csm.conf
+++ b/csm/conf/etc/csm/csm.conf
@@ -133,6 +133,7 @@ SUPPORT_BUNDLE:
     symlink_path: "/tmp/support_bundle/"
     cluster_file_path : "/opt/seagate/cortx/provisioner/pillar/components/cluster.sls"
     ssh_user : "root"
+    alerts_file_path: "/tmp/fru_alerts.json"
 
 UPDATE:
     firmware_store_path: "/tmp/fw_update/"

--- a/csm/conf/etc/csm/csm.conf
+++ b/csm/conf/etc/csm/csm.conf
@@ -133,7 +133,7 @@ SUPPORT_BUNDLE:
     symlink_path: "/tmp/support_bundle/"
     cluster_file_path : "/opt/seagate/cortx/provisioner/pillar/components/cluster.sls"
     ssh_user : "root"
-    alerts_file_path: "/tmp/fru_alerts.json"
+    alerts_filename: "fru_alerts.json"
 
 UPDATE:
     firmware_store_path: "/tmp/fw_update/"

--- a/csm/conf/etc/csm/csm.conf
+++ b/csm/conf/etc/csm/csm.conf
@@ -133,7 +133,7 @@ SUPPORT_BUNDLE:
     symlink_path: "/tmp/support_bundle/"
     cluster_file_path : "/opt/seagate/cortx/provisioner/pillar/components/cluster.sls"
     ssh_user : "root"
-    alerts_filename: "fru_alerts.json"
+    alerts_filename: "alerts.json"
 
 UPDATE:
     firmware_store_path: "/tmp/fw_update/"

--- a/csm/core/services/alerts.py
+++ b/csm/core/services/alerts.py
@@ -216,6 +216,57 @@ class AlertRepository(IAlertStorage):
         query = Query().filter_by(alert_filter)
         return await self.db(AlertModel).get(query)
 
+    async def fetch_alert_for_support_bundle(self):
+        """
+        Fetches New and Active alerts except for IEM alerts.
+        Fetches alerts whose life cycle is completed(resovled + ack) for 7 days.
+        1. Fetching New alerts (resolved and ack both false)
+        """
+        combined_alert_list = []
+        new_alerts_list = await self.retrieve_by_range(
+            None, #time_range
+            True, #show_all
+            None, #severity
+            None, #SortBy
+            None, #limits
+            False, #resolved,
+            False, #acknowledged,
+            False #show_active
+        )
+        combined_alert_list.extend(new_alerts_list)
+        """
+        2. Fetching active alerts (either resolved or ack) is true.
+        """
+        active_alerts_list = await self.retrieve_by_range(
+            None, #time_range
+            True, #show_all
+            None, #severity
+            None, #SortBy
+            None, #limits
+            None, #resolved,
+            None, #acknowledged,
+            True  #show_active
+        )
+        combined_alert_list.extend(active_alerts_list)
+        """
+        3. Fetching alerts that have been resolved and ack both.
+        This means that the alert has completed the life cycle.
+        For these alerts we will only fetch the data for last 7 days.
+        """
+        start_time = datetime.utcnow() - timedelta(**{"days": 7})
+        resolved_alerts_list = await self.retrieve_by_range(
+            DateTimeRange(start_time, None), #time_range
+            True, #show_all
+            None, #severity
+            None, #SortBy
+            None, #limits
+            True, #resolved,
+            True, #acknowledged,
+            False  #show_active
+        )
+        combined_alert_list.extend(resolved_alerts_list)
+        return [alert.to_primitive_filter_empty() for alert in combined_alert_list if not alert.module_type == const.IEM]
+
 class AlertsAppService(ApplicationService):
     """
         Provides operations on alerts without involving the domain specifics

--- a/schema/commands.yaml
+++ b/schema/commands.yaml
@@ -40,3 +40,5 @@ COMMANDS:
     - '<CORTX_PATH>/csm/conf/elasticsearch_setup.yaml'
   ha:
     - '/opt/seagate/cortx/ha/conf/setup.yaml'
+  alerts:
+    - '<CORTX_PATH>/csm/conf/alerts_setup.yaml'


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-14243
Add FRU Alerts as part of support bundle
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
Requirement was to add fru alerts to support bundle.
</pre>
## Solution
<pre>
Added fru alerts to support bundle
</pre>
## Unit Test Cases
<pre>
[root@ssc-vm-c-1058 722996]# cortxcli support_bundle generate -h
usage: cortxcli support_bundle generate [-h] [--os]
                                        [-c {all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest,alerts} [{all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest,alerts} ...]]
                                        comment

positional arguments:
  comment               Specify the Reason for Generating Support Bundle.

optional arguments:
  -h, --help            show this help message and exit
  --os                  Generate Only OS Logs
  -c {all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest,alerts} [{all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest,alerts} ...]
                        Generate Bundle for Specific components defined.


[root@ssc-vm-c-1058 722996]# cortxcli support_bundle generate test_alerts6 -c alerts
Please use the below bundle id for checking the status of support bundle.
--------------
| SBtljaort6 |
--------------
Please Find the file on -> /tmp/support_bundle/ .


[root@ssc-vm-c-1058 722996]# cortxcli support_bundle status SBtljaort6
+------------+--------------+--------------------------------+-------------------------------------------------+
| Bundle Id  |   Comment    |           Node Name            |                      Message                    |
+------------+--------------+--------------------------------+-------------------------------------------------+
| SBtljaort6 | test_alerts6 | ssc-vm-c-1059.colo.seagate.com | Tar file linked at location - /tmp/support_bundl|
| SBtljaort6 | test_alerts6 | ssc-vm-c-1059.colo.seagate.com |        Support bundle generation completed.     |
| SBtljaort6 | test_alerts6 | ssc-vm-c-1058.colo.seagate.com |        Support bundle generation completed.     |
| SBtljaort6 | test_alerts6 | ssc-vm-c-1059.colo.seagate.com |        Support bundle generation completed.     |
| SBtljaort6 | test_alerts6 | ssc-vm-c-1058.colo.seagate.com | Tar file linked at location - /tmp/support_bundl|
| SBtljaort6 | test_alerts6 | ssc-vm-c-1058.colo.seagate.com |        Support bundle generation completed.     |
+------------+--------------+--------------------------------+-------------------------------------------------+


[root@ssc-vm-c-1058 722996]# tar -tvf /tmp/support_bundle/SUPPORT_BUNDLE.SBtljaort6
drwxr-xr-x root/root         0 2020-10-18 19:00 SBtljaort6/
drwxr-xr-x root/root         0 2020-10-18 19:00 SBtljaort6/alerts/
-rw-r--r-- root/root      2318 2020-10-18 19:00 SBtljaort6/alerts_SBtljaort6.tar.gz
-rw-r--r-- root/root       137 2020-10-18 19:00 SBtljaort6/summary.yaml
</pre>
Signed-off-by: pawan.kumarsrivastava@seagate.com
