### PR TITLE
[Cortx-dev] Move csm logrotate conf to logrotate.d instead of logrotate_hourly.d

### DIFF
--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -433,7 +433,7 @@ DEST_CRON_PATH="{}/es_logrotate.cron".format(CRON_DIR)
 
 #logrotate
 LOGROTATE_DIR = "/etc/logrotate.d"
-LOGROTATE_DIR_DEST = "/etc/logrotate_hourly.d"
+LOGROTATE_DIR_DEST = "/etc/logrotate.d"
 
 # https status code
 STATUS_CREATED = 201


### PR DESCRIPTION
Signed-off-by: Naval Patel <naval.patel@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any):Move csm logrotate conf to logrotate.d instead of logrotate_hourly.d
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
/etc/logrotate_hourly.d/ folder is removed by provisioner.
</pre>
## Solution
<pre>
Moving csm logrotate conf file to /etc/logrotate.d
</pre>
## Unit Test Cases
<pre>
Checked file after csm_setup init. csm logrortate file gets created in /etc/logrotate.d/ folder
</pre>
Signed-off-by: 
