### PR TITLE
Add support bundle for ha

### DIFF
--- a/csm/cli/schema/bundle_generate.json
+++ b/csm/cli/schema/bundle_generate.json
@@ -33,7 +33,8 @@
         "provisioner",
         "os",
         "health_map",
-        "manifest"
+        "manifest",
+        "ha"
       ],
       "nargs": "+",
       "help": "Specific Component for Support Bundle to be Generated."

--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -34,7 +34,8 @@
             "provisioner",
             "os",
             "health_map",
-            "manifest"
+            "manifest",
+            "ha"
           ],
           "nargs": "+",
           "help": "Generate Bundle for Specific components defined."
@@ -108,4 +109,3 @@
     }
   ]
 }
-

--- a/schema/commands.yaml
+++ b/schema/commands.yaml
@@ -36,3 +36,5 @@ COMMANDS:
     - '<CORTX_PATH>/provisioner/conf/setup.yaml'
   manifest:
     - '<CORTX_PATH>/sspl/conf/manifest.yaml'
+  ha:
+    - '/opt/seagate/cortx/ha/conf/setup.yaml'


### PR DESCRIPTION
Signed-off-by: Ajay Paratmandali <ajay.paratmandali@seagate.com>
# Backend

Ref: https://github.com/Seagate/cortx-manager/pull/201 csm
Ref: https://github.com/Seagate/cortx-ha/pull/202 ha

## Problem Statement
<pre>
Story Ref (if any):
https://jts.seagate.com/browse/EOS-14006
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
Support bundle for ha is missing
</pre>
## Solution
<pre>
Add ha support bundle in cortxcli
</pre>
## Unit Test Cases
<pre>
Integration testing is done
No unit testing available.
</pre>