### PR TITLE
[Cortx-dev] EOS-14242 added additional elasticsearch log file for support_bundle

### DIFF
--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -40,14 +40,20 @@ class CSMBundle:
         # Read Config to Fetch Log File Path
         csm_log_directory_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.log_path")
         uds_log_directory_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.uds_log_path")
-        elasticsearch_log_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.elasticsearch_log_path")
+        es_cluster_log_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.es_cluster_log_path")
+        es_gc_log_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.es_gc_log_path")
+        es_indexing_log_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.es_indexing_log_path")
+        es_search_log_path = Conf.get(const.CSM_GLOBAL_INDEX, "Log.es_search_log_path")
         # Creates CSM Directory
         path = command.options.get("path")
         bundle_id = command.options.get("bundle_id")
         component_name = command.options.get("component", "csm")
         component_data = {"csm": [csm_log_directory_path],
                           "uds": [uds_log_directory_path],
-                          "elasticsearch": [elasticsearch_log_path]}
+                          "elasticsearch": [es_cluster_log_path,
+                                            es_gc_log_path,
+                                            es_indexing_log_path,
+                                            es_search_log_path]}
         temp_path = os.path.join(path, component_name)
         os.makedirs(temp_path, exist_ok = True)
         # Generate Tar file for Logs Folder.

--- a/csm/conf/etc/csm/csm.conf
+++ b/csm/conf/etc/csm/csm.conf
@@ -113,7 +113,10 @@ Log:
     log_path: "/var/log/seagate/csm/"
     max_result_window: 10000
     uds_log_path: "/var/log/uds"
-    elasticsearch_log_path: "/var/log/elasticsearch/elasticsearch_cluster.log"
+    es_cluster_log_path: "/var/log/elasticsearch/elasticsearch_cluster.log"
+    es_gc_log_path: "/var/log/elasticsearch/gc.log.0"
+    es_indexing_log_path: "/var/log/elasticsearch/elasticsearch_cluster_index_indexing_slowlog.log"
+    es_search_log_path: "/var/log/elasticsearch/elasticsearch_cluster_index_search_slowlog.log"
     usl_polling_log: false
 #CSMCLI
 CSMCLI:


### PR DESCRIPTION
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any):https://jts.seagate.com/browse/EOS-14242
Added additional files for elasticsearch support_bundle
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
Add support bundle for uds and elasticsearch.
  </code>
</pre>
## Solution
<pre>
  <code>
   Add support bundle for uds and elasticsearch.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    Yes/No
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
usage: cortxcli support_bundle generate [-h] [--os]
                                        [-c {all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest,uds,elasticsearch} [{all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest,uds,elasticsearch} ...]]
                                        comment

positional arguments:
  comment               Specify the Reason for Generating Support Bundle.

optional arguments:
  -h, --help            show this help message and exit
  --os                  Generate Only OS Logs
  -c {all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest,uds,elasticsearch} [{all,csm,sspl,s3server,core,hare,provisioner,os,health_map,manifest,uds,elasticsearch} ...]
                        Generate Bundle for Specific components defined. 

  </code>
</pre>
## CLI Command Output
<pre>
  <code>

[root@ssc-vm-1283 ~]# cortxcli support_bundle generate test_uds -c uds
Please use the below bundle id for checking the status of support bundle.
--------------
| SBzvkdkv9a |
--------------
Please Find the file on -> /tmp/support_bundle/ .

[root@ssc-vm-1283 ~]# tar -tvf /tmp/support_bundle/SUPPORT_BUNDLE.SBzvkdkv9a
drwxr-xr-x root/root         0 2020-10-15 15:51 SBzvkdkv9a/
drwxr-xr-x root/root         0 2020-10-15 15:51 SBzvkdkv9a/uds/
-rw-r--r-- root/root       198 2020-10-15 15:51 SBzvkdkv9a/uds_SBzvkdkv9a.tar.gz
-rw-r--r-- root/root       131 2020-10-15 15:51 SBzvkdkv9a/summary.yaml
[root@ssc-vm-1283 ~]#

[root@ssc-vm-1283 ~]# cortxcli support_bundle status  SBzvkdkv9a
+------------+----------+------------------------------+----------------------------------------------------+---------+
| Bundle Id  | Comment  |          Node Name           |                      Message                       |  Result |
+------------+----------+------------------------------+----------------------------------------------------+---------+
| SBzvkdkv9a | test_uds | ssc-vm-1283.colo.seagate.com | Tar file linked at location - /tmp/support_bundle/ | Success |
| SBzvkdkv9a | test_uds | ssc-vm-1283.colo.seagate.com |        Support bundle generation completed.        | Success |
| SBzvkdkv9a | test_uds | ssc-vm-1283.colo.seagate.com |        Support bundle generation completed.        | Success |
+------------+----------+------------------------------+----------------------------------------------------+---------+
[root@ssc-vm-1283 ~]#


Test elasticsearch support_bundle 

[root@ssc-vm-1283 ~]# cortxcli support_bundle generate test_es -c elasticsearch
Please use the below bundle id for checking the status of support bundle.
--------------
| SBrvlpcqon |
--------------
Please Find the file on -> /tmp/support_bundle/ .

[root@ssc-vm-1283 ~]# tar -tvf /tmp/support_bundle/SUPPORT_BUNDLE.SBrvlpcqon
drwxr-xr-x root/root         0 2020-10-15 15:55 SBrvlpcqon/
-rw-r--r-- root/root       130 2020-10-15 15:55 SBrvlpcqon/summary.yaml
drwxr-xr-x root/root         0 2020-10-15 15:55 SBrvlpcqon/elasticsearch/
-rw-r--r-- root/root       481 2020-10-15 15:55 SBrvlpcqon/elasticsearch_SBrvlpcqon.tar.gz
[root@ssc-vm-1283 ~]#
[root@ssc-vm-1283 ~]# cortxcli support_bundle status SBrvlpcqon
+------------+---------+------------------------------+----------------------------------------------------+---------+
| Bundle Id  | Comment |          Node Name           |                      Message                       |  Result |
+------------+---------+------------------------------+----------------------------------------------------+---------+
| SBrvlpcqon | test_es | ssc-vm-1283.colo.seagate.com | Tar file linked at location - /tmp/support_bundle/ | Success |
| SBrvlpcqon | test_es | ssc-vm-1283.colo.seagate.com |        Support bundle generation completed.        | Success |
| SBrvlpcqon | test_es | ssc-vm-1283.colo.seagate.com |        Support bundle generation completed.        | Success |
+------------+---------+------------------------------+----------------------------------------------------+---------+
[root@ssc-vm-1283 ~]#
  </code>
</pre>

