### PR TITLE
EOS-14372: Bucket list failing to return list for 500 bucket account

### DIFF
--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -400,6 +400,7 @@ LOG_LEVEL = "INFO"
 USL_POLLING_LOG = "usl_polling_log"
 
 # Set network config
+NETWORK_CONFIG = 'network_config'
 MANAGEMENT_NETWORK = 'management_network_settings'
 DATA_NETWORK = 'data_network_settings'
 DNS_NETWORK = 'dns_network_settings'

--- a/csm/plugins/cortx/provisioner.py
+++ b/csm/plugins/cortx/provisioner.py
@@ -28,6 +28,7 @@ from json import JSONDecodeError
 from csm.common.payload import JsonMessage
 import provisioner
 import provisioner.freeze
+from csm.common.conf import Conf
 
 
 class PackageValidationError(InvalidRequest):
@@ -58,7 +59,6 @@ class ProvisionerPlugin:
     PRVSNR_NETWORK_PARAM_CIP = 'network/cluster_ip'
 
     def __init__(self, username=None, password=None):
-        self.network_config = None
         try:
             self.provisioner = provisioner
             Log.info("Provisioner plugin is loaded")
@@ -252,8 +252,8 @@ class ProvisionerPlugin:
         :returns: an instance of NetworkConfiguirationResponse
         :raises: a CsmInternalError in case of query failure
         """
-        if not self.network_config:
-            Log.debug("Netword config is not present in in-memory.")
+        if not Conf.get(const.CSM_GLOBAL_INDEX, const.NETWORK_CONFIG):
+            Log.debug("Network config is not present in in-memory.")
             if not self.provisioner:
                 raise NetworkConfigFetchError(const.PROVISIONER_PACKAGE_NOT_INIT)
 
@@ -269,10 +269,12 @@ class ProvisionerPlugin:
                 except Exception as error:
                     Log.error(f"Provisioner api error : {error}")
                     raise NetworkConfigFetchError(f"Network configuration fetching failed: {error}")
-            self.network_config = await self._await_nonasync(_command_handler)
-            Log.debug(f"Netowrk config fetched from provisioner, set in in-memory: {self.network_config}")
+            network_config = await self._await_nonasync(_command_handler)
+            Conf.set(const.CSM_GLOBAL_INDEX, const.NETWORK_CONFIG, network_config)
+            Conf.save()
+            Log.debug(f"Netowrk config fetched from provisioner, set in in-memory: {network_config}")
 
-        return self.network_config
+        return Conf.get(const.CSM_GLOBAL_INDEX, const.NETWORK_CONFIG)
 
     @Log.trace_method(Log.DEBUG)
     async def get_cluster_id(self):

--- a/csm/plugins/cortx/provisioner.py
+++ b/csm/plugins/cortx/provisioner.py
@@ -58,6 +58,7 @@ class ProvisionerPlugin:
     PRVSNR_NETWORK_PARAM_CIP = 'network/cluster_ip'
 
     def __init__(self, username=None, password=None):
+        self.network_config = None
         try:
             self.provisioner = provisioner
             Log.info("Provisioner plugin is loaded")
@@ -251,23 +252,27 @@ class ProvisionerPlugin:
         :returns: an instance of NetworkConfiguirationResponse
         :raises: a CsmInternalError in case of query failure
         """
-        if not self.provisioner:
-            raise NetworkConfigFetchError(const.PROVISIONER_PACKAGE_NOT_INIT)
+        if not self.network_config:
+            Log.debug("Netword config is not present in in-memory.")
+            if not self.provisioner:
+                raise NetworkConfigFetchError(const.PROVISIONER_PACKAGE_NOT_INIT)
 
-        def _command_handler():
-            try:
-                response = self.provisioner.get_params(self.PRVSNR_NETWORK_PARAM_VIP, self.PRVSNR_NETWORK_PARAM_CIP)
-                # The IPs are same for each node, so we can take any of them
-                for node, params in response.items():
-                    return NetworkConfiguirationResponse(
-                        mgmt_vip=params[self.PRVSNR_NETWORK_PARAM_VIP],
-                        cluster_ip=params[self.PRVSNR_NETWORK_PARAM_CIP]
-                    )
-            except Exception as error:
-                Log.error(f"Provisioner api error : {error}")
-                raise NetworkConfigFetchError(f"Network configuration fetching failed: {error}")
+            def _command_handler():
+                try:
+                    response = self.provisioner.get_params(self.PRVSNR_NETWORK_PARAM_VIP, self.PRVSNR_NETWORK_PARAM_CIP)
+                    # The IPs are same for each node, so we can take any of them
+                    for node, params in response.items():
+                        return NetworkConfiguirationResponse(
+                            mgmt_vip=params[self.PRVSNR_NETWORK_PARAM_VIP],
+                            cluster_ip=params[self.PRVSNR_NETWORK_PARAM_CIP]
+                        )
+                except Exception as error:
+                    Log.error(f"Provisioner api error : {error}")
+                    raise NetworkConfigFetchError(f"Network configuration fetching failed: {error}")
+            self.network_config = await self._await_nonasync(_command_handler)
+            Log.debug(f"Netowrk config fetched from provisioner, set in in-memory: {self.network_config}")
 
-        return await self._await_nonasync(_command_handler)
+        return self.network_config
 
     @Log.trace_method(Log.DEBUG)
     async def get_cluster_id(self):


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): EOS-14372
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description 
<pre>
Bucket list failing to return list for 500 bucket account
</pre>
## Solution: 
<pre>
Stored network configuration fetched from provisioner in in-memory. So while creating s3_url, it will get the cluster IP from in-memory instead of fetching it from provisioner evry time. 
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: Soniya Moholkar
