### PR TITLE
[CORTX-DEV] EOS-14335-cortx-dev: Alerts not visible for Pvt data nw

### DIFF
--- a/csm/common/comm.py
+++ b/csm/common/comm.py
@@ -262,14 +262,12 @@ class AmqpChannel(Channel):
                                               self.exchange_type,
                                               str(err)))
             try:
-                debug_queue = self._channel.queue_declare(queue=self.exchange_queue,
+                self._channel.queue_declare(queue=self.exchange_queue,
                                             exclusive=self.exclusive, \
                                                     durable=self.durable)
                 self._channel.queue_bind(exchange=self.exchange,
                                          queue=self.exchange_queue,
                                          routing_key=self.routing_key)
-                Log.info(f"Pvt DATA network debug: Number of messages on queue: {self.exchange_queue}"
-                        f" is {debug_queue.method.message_count}")
                 Log.info(f'Initialized Exchange: {self.exchange}, '
                         f'Queue: {self.exchange_queue}, routing_key: {self.routing_key}')
             except AMQPError as err:

--- a/csm/common/comm.py
+++ b/csm/common/comm.py
@@ -262,12 +262,14 @@ class AmqpChannel(Channel):
                                               self.exchange_type,
                                               str(err)))
             try:
-                self._channel.queue_declare(queue=self.exchange_queue,
+                debug_queue = self._channel.queue_declare(queue=self.exchange_queue,
                                             exclusive=self.exclusive, \
                                                     durable=self.durable)
                 self._channel.queue_bind(exchange=self.exchange,
                                          queue=self.exchange_queue,
                                          routing_key=self.routing_key)
+                Log.info(f"Pvt DATA network debug: Number of messages on queue: {self.exchange_queue}"
+                        f" is {debug_queue.method.message_count}")
                 Log.info(f'Initialized Exchange: {self.exchange}, '
                         f'Queue: {self.exchange_queue}, routing_key: {self.routing_key}')
             except AMQPError as err:

--- a/csm/conf/etc/csm/csm.conf
+++ b/csm/conf/etc/csm/csm.conf
@@ -155,3 +155,6 @@ SECURITY:
 
 MAINTENANCE:
     shutdown_cron_time: 60
+
+ELASTICSEARCH:
+    retry: 5

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -601,3 +601,4 @@ STORAGE_TYPE_VIRTUAL = "virtual"
 
 L18N_SCHEMA = '{}/schema/l18n.json'.format(CSM_PATH)
 SHUTDOWN_CRON_TIME = "shutdown_cron_time"
+ES_RETRY = "ELASTICSEARCH.retry"

--- a/csm/plugins/cortx/alert.py
+++ b/csm/plugins/cortx/alert.py
@@ -176,7 +176,7 @@ class AlertPlugin(CsmPlugin):
                     """
                     Calling HA Decision Maker for Alerts.
                     """
-                    if self.decision_maker_service:
+                    if self.decision_maker_service and status:
                         self.decision_maker_service.decision_maker_callback(sensor_queue_msg)
             except ValidationError as ve:
                 # Acknowledge incase of validation error.

--- a/csm/plugins/cortx/alert.py
+++ b/csm/plugins/cortx/alert.py
@@ -183,9 +183,8 @@ class AlertPlugin(CsmPlugin):
                 Log.warn(f"Acknowledge incase of validation error {ve}")
                 self.comm_client.acknowledge()
             except Exception as e:
-                Log.warn(f"Silently acknowledge ill-formed CSM alerts: {e}")
-                # Silently acknowledge ill-formed CSM alerts
-                self.comm_client.acknowledge()
+                # Code should not reach here.
+                Log.warn(f"Error occured during processing alerts: {e}")
         if status:
             # Acknowledge the alert so that it could be
             # removed from the queue.


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-14335
Private data network port down on a node where CSM is running is not seen by CSM
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
When Pvt nw is down elasticsearch also went down. So, when CSM receives the alert due to elasticsearch is still in cloning process CSM is not able to save the alert in db. Also, CSM ack that alert and it omits from RMQ. 
</pre>
## Solution
<pre>
Elasticsearch cloning requires few seconds so we will try to first connect to elasticsearch and then start the process of saving the alerts. Also, in case of any exception we will not ack the alert so that it remains in RMQ.
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: pawan.kumarsrivastava@seagate.com
