### PR TITLE
[CORTX-dev] EOS-14531 moved bundle file for csm, uds, elasticsearch inside corressponding folder

### DIFF
--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -51,7 +51,7 @@ class CSMBundle:
         temp_path = os.path.join(path, component_name)
         os.makedirs(temp_path, exist_ok = True)
         # Generate Tar file for Logs Folder.
-        tar_file_name = os.path.join(path, f"{component_name}_{bundle_id}.tar.gz")
+        tar_file_name = os.path.join(temp_path, f"{component_name}_{bundle_id}.tar.gz")
         if all(map(os.path.exists, component_data[component_name])):
             Tar(tar_file_name).dump(component_data[component_name])
         else:


### PR DESCRIPTION


Signed-off-by: Naval Patel <naval.patel@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any):https://jts.seagate.com/browse/EOS-14531
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
tar file was created outside uds/elastisearch folder
</pre>
## Solution
<pre>
created tar file inside corresponding component folder 
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: 
