### PR TITLE
[MAIN] EOS-14335: Alerts not visible for Pvt data nw

### DIFF
--- a/csm/conf/etc/csm/csm.conf
+++ b/csm/conf/etc/csm/csm.conf
@@ -144,3 +144,6 @@ SECURITY:
 
 MAINTENANCE:
     shutdown_cron_time: 60
+
+ELASTICSEARCH:
+    retry: 5

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -607,3 +607,4 @@ OK = 'ok'
 EMPTY_PASS_FIELD = "Password field can't be empty."
 HEALTH_REQUIRED_FIELDS = {'health', 'severity', 'alert_uuid', 'alert_type'}
 SHUTDOWN_CRON_TIME = "shutdown_cron_time"
+ES_RETRY = "ELASTICSEARCH.retry"

--- a/csm/core/services/alerts.py
+++ b/csm/core/services/alerts.py
@@ -40,6 +40,7 @@ from schematics.types import StringType, BooleanType, IntType
 from typing import Optional, Iterable, Dict
 from csm.common.payload import Payload, Json, JsonMessage
 import asyncio
+from csm.common.conf import Conf
 
 
 ALERTS_MSG_INVALID_DURATION = "alert_invalid_duration"
@@ -572,6 +573,7 @@ class AlertMonitorService(Service, Observable):
         self.repo = repo
         self._health_plugin = health_plugin
         self._http_notfications = http_notifications
+        self._es_retry = Conf.get(const.CSM_GLOBAL_INDEX, const.ES_RETRY, 5)
         super().__init__()
 
     def _monitor(self):
@@ -608,6 +610,28 @@ class AlertMonitorService(Service, Observable):
             self._thread_running = False
         except Exception as e:
             Log.warn(f"Error in stopping alert monitor thread: {e}")
+
+    def _get_previous_alert(self, sensor_info, module_type):
+        """
+        This method fetches the prev alert. Before saving the alert into
+        ES DB we get the previous state of the alert.
+        During fault on the private network ES might take some time to clone
+        the data. During this duration if an alert comes CSM wont be able to
+        save it in ES and alert will be lost.
+        So, to handle this corner case when an exception comes we will sleep for
+        5 seconds and then will retry the ES connection.
+        Even if more then one alert piles up on RMQ queue this fix will handle it.
+        """
+        prev_alert = None
+        for count in range(0, self._es_retry):
+            try:
+                prev_alert = self._run_coroutine\
+                    (self.repo.retrieve_by_sensor_info(sensor_info, module_type))
+                return prev_alert
+            except Exception as ex:
+                Log.warn(f"Unable to fetch previous alert. Retrying : {count+1}.{ex}")
+                time.sleep(2**count)
+                continue
 
     def _consume(self, message):
         """
@@ -656,8 +680,7 @@ class AlertMonitorService(Service, Observable):
             """
             if is_node_alert and is_high_risk_severity:
                 self._add_support_message(message)
-            prev_alert = self._run_coroutine\
-                    (self.repo.retrieve_by_sensor_info(sensor_info, module_type))
+            prev_alert = self._get_previous_alert(sensor_info, module_type)
             alert = AlertModel(message)
             if not prev_alert:
                 self._run_coroutine(self.repo.store(alert))
@@ -686,6 +709,7 @@ class AlertMonitorService(Service, Observable):
             self._run_coroutine(self.repo.store_alerts_history(alert_history))
         except Exception as e:
             Log.warn(f"Error in consuming alert: {e}")
+            return False
 
         return True
 

--- a/csm/plugins/cortx/alert.py
+++ b/csm/plugins/cortx/alert.py
@@ -176,16 +176,15 @@ class AlertPlugin(CsmPlugin):
                     """
                     Calling HA Decision Maker for Alerts.
                     """
-                    if self.decision_maker_service:
+                    if self.decision_maker_service and status:
                         self.decision_maker_service.decision_maker_callback(sensor_queue_msg)
             except ValidationError as ve:
                 # Acknowledge incase of validation error.
                 Log.warn(f"Acknowledge incase of validation error {ve}")
                 self.comm_client.acknowledge()
             except Exception as e:
-                Log.warn(f"Silently acknowledge ill-formed CSM alerts: {e}")
-                # Silently acknowledge ill-formed CSM alerts
-                self.comm_client.acknowledge()
+                # Code should not reach here.
+                Log.warn(f"Error occured during processing alerts: {e}")
         if status:
             # Acknowledge the alert so that it could be
             # removed from the queue.


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-14335
Private data network port down on a node where CSM is running is not seen by CSM
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
When Pvt nw is down elasticsearch also went down. So, when CSM receives the alert due to elasticsearch is still in cloning process CSM is not able to save the alert in db. Also, CSM ack that alert and it omits from RMQ. 
</pre>
## Solution
<pre>
Elasticsearch cloning requires few seconds so we will try to first connect to elasticsearch and then start the process of saving the alerts. Also, in case of any exception we will not ack the alert so that it remains in RMQ.
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: pawan.kumarsrivastava@seagate.com
