### PR TITLE
Build is failing due to CSM PATH is not available

### DIFF
--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -24,9 +24,9 @@ CORTXCLI_PATH="${CORTX_PATH}cli"
 DEBUG="DEBUG"
 INFO="INFO"
 PROVISIONER_CONFIG_PATH="${CORTX_PATH}provisioner/generated_configs"
-CORTX_UNSUPPORTED_FEATURES_PATH="${CSM_PATH}/schema/unsupported_features.json"
+CORTX_UNSUPPORTED_FEATURES_PATH="${BASE_DIR}/schema/unsupported_features.json"
 BRAND_UNSUPPORTED_FEATURES_PATH="config/csm/unsupported_features.json"
-CORTX_L18N_PATH="${CSM_PATH}/schema/l18n.json"
+CORTX_L18N_PATH="${BASE_DIR}/schema/l18n.json"
 BRAND_L18N_PATH="config/csm/l18n.json"
 
 print_time() {


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): 
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
Build is failing for LDR build.
</pre>
## Solution
<pre>
Updated CSM_PATH to BASE_DIR
</pre>
## Unit Test Cases
<pre>
NA
</pre>
Signed-off-by: Soniya Moholkar
