### PR TITLE
[Main] EOS-14633 Added local timezone to date format

### DIFF
--- a/cicd/pyinstaller/requirment.txt
+++ b/cicd/pyinstaller/requirment.txt
@@ -25,3 +25,4 @@ cryptography==2.8
 python-crontab==2.5.1
 confluent-kafka==1.5.0
 netifaces==0.10.9
+tzlocal==2.1

--- a/cicd/pyinstaller/requirment.txt
+++ b/cicd/pyinstaller/requirment.txt
@@ -25,4 +25,3 @@ cryptography==2.8
 python-crontab==2.5.1
 confluent-kafka==1.5.0
 netifaces==0.10.9
-tzlocal==2.1

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -95,6 +95,9 @@ OS_PERMISSION_DENIED = 2000
 # File Collector
 BUNDLE_FILE = 'files.tgz'
 
+# Security
+CERT_TIME_FORMAT = "%Y-%m-%d %H:%M:%S %Z%z"
+
 # Poll check internal
 RESPONSE_CHECK_INTERVAL = 1
 

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -96,7 +96,7 @@ OS_PERMISSION_DENIED = 2000
 BUNDLE_FILE = 'files.tgz'
 
 # Security
-CERT_TIME_FORMAT = "%Y-%m-%d %H:%M:%S %Z%z"
+CERT_TIME_FORMAT = "%Y-%m-%d %H:%M:%S %Z"
 
 # Poll check internal
 RESPONSE_CHECK_INTERVAL = 1

--- a/csm/core/services/security.py
+++ b/csm/core/services/security.py
@@ -20,7 +20,6 @@ from datetime import datetime
 from string import Template
 from typing import Union
 from datetime import datetime, timedelta, timezone
-from tzlocal import get_localzone
 from concurrent.futures import ThreadPoolExecutor
 
 from cryptography import x509
@@ -316,7 +315,7 @@ class SecurityService(ApplicationService):
         """
         Convert utc aware time to local timezone and print in specific format
         """
-        local_time = from_time.astimezone(get_localzone())
+        local_time = from_time.astimezone()
         return local_time.strftime(const.CERT_TIME_FORMAT)
 
     async def _check_certificate_expiry_time(self, current_time):

--- a/csm/core/services/security.py
+++ b/csm/core/services/security.py
@@ -315,20 +315,20 @@ class SecurityService(ApplicationService):
         """
         Convert utc aware time to local timezone and print in specific format
         """
-        local_time = from_time.astimezone()
-        return local_time.strftime(const.CERT_TIME_FORMAT)
+        converted_time_ltz = from_time.astimezone()
+        return converted_time_ltz.strftime(const.CERT_TIME_FORMAT)
 
     async def _check_certificate_expiry_time(self, current_time):
         warning_days = Conf.get(const.CSM_GLOBAL_INDEX, "SECURITY.ssl_cert_expiry_warning_days")
         try:
             expiry_time = await self.get_certificate_expiry_time()
             expiry_time = expiry_time.replace(tzinfo=timezone.utc)
-            local_time = self._local_timezone(expiry_time)
+            expiry_time_ltz = self._local_timezone(expiry_time)
             days_left = (expiry_time.date() - current_time.date()).days
             if expiry_time < current_time:
-                message = f'SSL certificate expired at {local_time}'
+                message = f'SSL certificate expired at {expiry_time_ltz}'
             elif days_left in warning_days:
-                message = f'SSL certificate expires at {local_time} - {days_left} day(s) left'
+                message = f'SSL certificate expires at {expiry_time_ltz} - {days_left} day(s) left'
             else:
                 message = None
 

--- a/csm/core/services/security.py
+++ b/csm/core/services/security.py
@@ -318,18 +318,18 @@ class SecurityService(ApplicationService):
         """
         local_time = from_time.astimezone(get_localzone())
         return local_time.strftime(const.CERT_TIME_FORMAT)
-        
+
     async def _check_certificate_expiry_time(self, current_time):
         warning_days = Conf.get(const.CSM_GLOBAL_INDEX, "SECURITY.ssl_cert_expiry_warning_days")
         try:
             expiry_time = await self.get_certificate_expiry_time()
             expiry_time = expiry_time.replace(tzinfo=timezone.utc)
-            local_time = self._local_timezone(expriy_time)
+            local_time = self._local_timezone(expiry_time)
             days_left = (expiry_time.date() - current_time.date()).days
             if expiry_time < current_time:
                 message = f'SSL certificate expired at {local_time}'
             elif days_left in warning_days:
-                message = f'SSL certificate expires at {local_timee} - {days_left} day(s) left'
+                message = f'SSL certificate expires at {local_time} - {days_left} day(s) left'
             else:
                 message = None
 


### PR DESCRIPTION
Signed-off-by: Naval Patel <naval.patel@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any):https://jts.seagate.com/browse/EOS-14633
local timezone not printed in date
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
Local timezone of server is not in date  
</pre>
## Solution
<pre>
Added local timezone in date format
</pre>
## Unit Test Cases
<pre>
Tested code snippet independently 

Output date format is 
2020-10-27 04:14:48 UTC+0000
2020-10-27 09:44:48 IST+0530
</pre>
Signed-off-by: 
