### PR TITLE
[Main] EOS-14633 Added await for async call

### DIFF
--- a/csm/core/services/security.py
+++ b/csm/core/services/security.py
@@ -323,7 +323,7 @@ class SecurityService(ApplicationService):
         try:
             expiry_time = await self.get_certificate_expiry_time()
             expiry_time = expiry_time.replace(tzinfo=timezone.utc)
-            expiry_time_ltz = self._local_timezone(expiry_time)
+            expiry_time_ltz = await self._local_timezone(expiry_time)
             days_left = (expiry_time.date() - current_time.date()).days
             if expiry_time < current_time:
                 message = f'SSL certificate expired at {expiry_time_ltz}'


### PR DESCRIPTION
Signed-off-by: Naval Patel <naval.patel@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any):https://jts.seagate.com/browse/EOS-14633
Corrected one call for async by await
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
Local timezone of server is not in date  
</pre>
## Solution
<pre>
Added local timezone in date format
</pre>
## Unit Test Cases
<pre>
Tested code snippet independently 

Output date format is 
2020-10-27 04:14:48 UTC
2020-10-27 09:44:48 IST
</pre>
Signed-off-by: 
