### PR TITLE
[Crtx-dev] EOS-14746 returned account_id and canonical_id on s3account create

### DIFF
--- a/csm/cli/schema/s3accounts.json
+++ b/csm/cli/schema/s3accounts.json
@@ -103,6 +103,8 @@
             "headers":{
               "account_name":"Account Name",
               "account_email":"Account Email",
+              "account_id":"Account Id",
+              "canonical_id":"Canonical Id",
               "access_key":"Permanent Access Key",
               "secret_key":"Permanent Secret Key"
             }

--- a/csm/core/services/s3/accounts.py
+++ b/csm/core/services/s3/accounts.py
@@ -78,6 +78,8 @@ class S3AccountService(S3BaseService):
         return {
             "account_name": account.account_name,
             "account_email": account.account_email,
+            "account_id": account.account_id,
+            "canonical_id": account.canonical_id,
             "access_key": account.access_key_id,
             "secret_key": account.secret_key_id
         }


### PR DESCRIPTION
Signed-off-by: Naval Patel <naval.patel@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-14746
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
Need additional fields from s3 account creations
</pre>
## Solution
<pre>
Returned requested fields
</pre>
## Unit Test Cases
<pre>
cortxcli$ s3accounts create s3_acc_cli s3_cli@test.com

Password must contain the following.
1) 1 upper and lower case character.
2) 1 numeric character.
3) 1 of the !@#$%^&*()_+-=[]{}|' characters.
Password:
Confirm Password:
Are you sure you want to perform "s3accounts create" command? [Y/n] y
+--------------+-----------------+--------------+------------------------------------------------------------------+------------------------+------------------------------------------+
| Account Name |  Account Email  |  Account Id  |                           Canonical Id                           |  Permanent Access Key  |           Permanent Secret Key           |
+--------------+-----------------+--------------+------------------------------------------------------------------+------------------------+------------------------------------------+
|  s3_acc_cli  | s3_cli@test.com | 431940400103 | e6c0e3046e8b48e7b4dbc22da34eb1cf5c9e63f8abd241c781d8b370be84642c | benN4wAMT-ivj-vVoUjXpg | 5qFHUHrRvGYtblAZLzXbUDh+oJPtqPkcwW3vbqbb |
+--------------+-----------------+--------------+------------------------------------------------------------------+------------------------+------------------------------------------+

</pre>
Signed-off-by: 
