### PR TITLE
[Cortx 1.0] EOS-14839 log file after rotation will have epoch time

### DIFF
--- a/csm/conf/etc/logrotate.d/csm/csm_agent_log-virtual.conf
+++ b/csm/conf/etc/logrotate.d/csm/csm_agent_log-virtual.conf
@@ -19,6 +19,7 @@
     rotate 3
     size 10M
     compress
+    dateext dateformat -%Y-%m-%d-%s
     postrotate
         /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
     endscript

--- a/csm/conf/etc/logrotate.d/csm/csm_agent_log.conf
+++ b/csm/conf/etc/logrotate.d/csm/csm_agent_log.conf
@@ -19,6 +19,7 @@
     rotate 10
     size 10M
     compress
+    dateext dateformat -%Y-%m-%d-%s
     postrotate
         /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
     endscript


### PR DESCRIPTION
Signed-off-by: Naval Patel <naval.patel@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any):https://jts.seagate.com/browse/EOS-14839
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
Log file after rotation has date, which is allowing only one file per day. This has changed recently in logrotate.conf global setting, which broke. csm logs for hourly.
</pre>
## Solution
<pre>
Added date and epoch to rotated files. This will allow multiple files to created on each day.
</pre>
## Unit Test Cases
<pre>
Forcefully invoked new conf file
# logrotate -fv  /etc/logrotate.d/csm_agent_log.conf

output after change 
[root@ssc-vm-1283 721542]# ls -l /var/log/seagate/csm/
total 3340
-rw-rwxr--+ 1 root root    2054 Nov  2 16:27 cortxcli.log-2020-11-03-1604419015.gz
-rw-rw----  1 root wheel 150348 Nov  3 16:14 csm_agent.log
-rw-rw----  1 root wheel 342260 Nov  3 06:10 csm_agent.log.0.gz
-rw-rwx---+ 1 root wheel 407761 Nov  2 19:11 csm_agent.log.1.gz
-rw-rw----  1 root wheel 114947 Nov  3 11:25 csm_agent.log-2020-11-03-1604419015.gz -- this  new format 
-rw-r--r--  1 root root    3094 Nov  3 15:59 csm_agent.log-2020-11-03-1604419194.gz
-rw-r--r--  1 root root    1074 Nov  3 16:01 csm_agent.log-2020-11-03-1604419301.gz
-rw-r--r--  1 root root    1194 Nov  3 16:03 csm_agent.log-2020-11-03-1604419426.gz
-rw-rwx---+ 1 root wheel 415674 Nov  2 08:14 csm_agent.log.2.gz  ---- these were old format 
-rw-rwx---+ 1 root wheel 388423 Nov  1 17:03 csm_agent.log.3.gz
-rw-rwx---+ 1 root wheel 352445 Nov  1 04:04 csm_agent.log.4.gz
-rw-rwx---+ 1 root wheel 361742 Oct 31 16:15 csm_agent.log.5.gz
-rw-rwx---+ 1 root wheel 356633 Oct 31 03:08 csm_agent.log.6.gz
-rw-rwx---+ 1 root wheel 462683 Oct 30 14:11 csm_agent.log.7.gz

</pre>
Signed-off-by: 
