### PR TITLE
[Cortx 1.0] EOS-14896 Updated Iam username and bucket name validation

### DIFF
--- a/csm/core/controllers/s3/iam_users.py
+++ b/csm/core/controllers/s3/iam_users.py
@@ -20,7 +20,7 @@ from csm.common.errors import InvalidRequest
 from csm.common.permission_names import Resource, Action
 from csm.core.controllers.validators import (PathPrefixValidator,
                                              PasswordValidator,
-                                             UserNameValidator)
+                                             IamUserNameValidator)
 from csm.core.controllers.view import CsmView, CsmAuth
 from csm.core.controllers.s3.base import S3AuthenticatedView
 
@@ -46,7 +46,7 @@ class IamUserCreateSchema(BaseSchema):
     IAM user Create schema validation class
     """
     user_name = fields.Str(required=True,
-                           validate=[UserNameValidator()])
+                           validate=[IamUserNameValidator()])
     password = fields.Str(required=True, validate=[PasswordValidator()])
     require_reset = fields.Boolean(default=False)
 
@@ -61,7 +61,7 @@ class IamUserDeleteSchema(BaseSchema):
     """
     IAM user delete schema validation class
     """
-    user_name = fields.Str(required=True, validate=[UserNameValidator()])
+    user_name = fields.Str(required=True, validate=[IamUserNameValidator()])
 
 
 @CsmView._app_routes.view("/api/v1/iam_users")

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -37,7 +37,7 @@ class IamUserNameValidator(Validator):
     def __call__(self, value):
         if not re.search(r"^[\w@+=.,-]{1,64}$", value):
             raise ValidationError(
-                "Iam username should be between 1-64 Characters"
+                "Iam username should be between 1-64 Characters."
                 "Should contain Alphanumeric - _ @ + = or ,.")
 
 

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -104,14 +104,14 @@ class BucketNameValidator(Validator):
     """
 
     def is_value_valid(self, value):
-        return re.search(r"^[a-z0-9][a-z0-9-]{3,54}[a-z0-9]$", value)
+        return re.search(r"^[a-z0-9][a-z0-9-.]{3,54}[a-z0-9]$", value)
 
     def __call__(self, value):
         if not self.is_value_valid(value):
             raise ValidationError(
                 ("Bucket Name should be between 4-56 Characters long."
-                 "Should contain either lowercase, numeric or '-' characters. "
-                 "Not starting or ending with '-'"))
+                 "Should contain either lowercase, numeric, '-' or '.' characters. "
+                 "Not starting or ending with '-' or '.'"))
 
 
 class Ipv4(Validator):

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -31,7 +31,7 @@ class FileRefValidator(Validator):
 
 class IamUserNameValidator(Validator):
     """
-    Validator Class for Iam Username 
+    Validator Class for Iam Username
     """
 
     def __call__(self, value):

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -38,7 +38,7 @@ class IamUserNameValidator(Validator):
         if not re.search(r"^[\w@+=.,-]{1,64}$", value):
             raise ValidationError(
                 "Iam username should be between 1-64 Characters."
-                "Should contain Alphanumeric - _ @ + = or ,.")
+                "Should contain Alphanumeric . - _ @ + = or ,.")
 
 
 class UserNameValidator(Validator):

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -122,7 +122,7 @@ class BucketNameValidator(Validator):
             ipv4 = Ipv4()
             ipv4(value)
             res = True
-        except ValidationError as e:
+        except ValidationError:
             res = False
         if res:
             raise ValidationError("Bucket Name cannot be ip v4 format")
@@ -138,7 +138,7 @@ class BucketNameValidator(Validator):
             raise ValidationError("Bucket Name cannot start with 'xn--'")
 
         self._check_ipv4(value)
-       
+
 
 class Ipv4(Validator):
     """

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -29,6 +29,17 @@ class FileRefValidator(Validator):
             raise ValidationError('This field must be of instance of a FileRef class')
 
 
+class IamUserNameValidator(Validator):
+    """
+    Validator Class for Iam Username 
+    """
+
+    def __call__(self, value):
+        if not re.search(r"^[\w@+=.,-]{1,64}", value):
+            raise ValidationError(
+                "Iam username should be between 1-64 Characters"
+                "Should contain Alphanumeric, -,_,@,+,= and ','.")
+
 
 class UserNameValidator(Validator):
     """
@@ -39,7 +50,7 @@ class UserNameValidator(Validator):
         if not re.search(r"^[a-zA-Z0-9_-]{4,56}$", value):
             raise ValidationError(
                 "Username can only contain Alphanumeric, - and  _ .Length "
-                "Must be between 4-64 Characters")
+                "Must be between 4-56 Characters")
 
 
 class CommentsValidator(Validator):
@@ -109,9 +120,12 @@ class BucketNameValidator(Validator):
     def __call__(self, value):
         if not self.is_value_valid(value):
             raise ValidationError(
-                ("Bucket Name should be between 4-56 Characters long."
+                ("Bucket Name should be between 3-63 Characters long."
                  "Should contain either lowercase, numeric, '-' or '.' characters. "
                  "Not starting or ending with '-' or '.'"))
+
+        if value.startswith("xn--"):
+            raise ValidationError("Bucket Name cannot start with 'xn--'")
 
 
 class Ipv4(Validator):

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -35,10 +35,10 @@ class IamUserNameValidator(Validator):
     """
 
     def __call__(self, value):
-        if not re.search(r"^[\w@+=.,-]{1,64}", value):
+        if not re.search(r"^[\w@+=.,-]{1,64}$", value):
             raise ValidationError(
                 "Iam username should be between 1-64 Characters"
-                "Should contain Alphanumeric, -,_,@,+,= and ','.")
+                "Should contain Alphanumeric - _ @ + = or ,.")
 
 
 class UserNameValidator(Validator):

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -115,7 +115,17 @@ class BucketNameValidator(Validator):
     """
 
     def is_value_valid(self, value):
-        return re.search(r"^[a-z0-9][a-z0-9-.]{3,54}[a-z0-9]$", value)
+        return re.search(r"^[a-z0-9][a-z0-9-.]{1,61}[a-z0-9]$", value)
+
+    def _check_ipv4(self, value):
+        try:
+            ipv4 = Ipv4()
+            ipv4(value)
+            res = True
+        except ValidationError as e:
+            res = False
+        if res:
+            raise ValidationError("Bucket Name cannot be ip v4 format")
 
     def __call__(self, value):
         if not self.is_value_valid(value):
@@ -127,6 +137,8 @@ class BucketNameValidator(Validator):
         if value.startswith("xn--"):
             raise ValidationError("Bucket Name cannot start with 'xn--'")
 
+        self._check_ipv4(value)
+       
 
 class Ipv4(Validator):
     """


### PR DESCRIPTION
Signed-off-by: Naval Patel <naval.patel@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any):https://jts.seagate.com/browse/EOS-14896
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
Bucket name validation does not allow '.'
</pre>
## Solution
<pre>
Added separate validation for Iam username
Length of the name should be between 1 and 64 characters. 
It should match the regex pattern [\w+=,.@-]+

Added validation for Bucket Name
Bucket names must be between 3 and 63 characters long. 
Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens . 
Bucket names must begin and end with a letter or number. 
Bucket names must not be formatted as an IP address (for example, 192.168.5.4). 
Bucket names can't begin with xn-- 
</pre>
## Unit Test Cases
<pre>
Tested using postman 
REST API api/v1/iam_users
POST calls

Valid IAM user
OUTPUTs
{
    "user_name": "Special_character@+=-_.valid",
    "user_id": "AIDA55D80045F19A449A8",
    "arn": "arn:aws:iam::463762618507:user/Special_character@+=-_.valid",
    "access_key_id": "bKmPs4t6S62wKoSufjU9XA",
    "secret_key": "Ejam1H2bMFXRi66cjzznvgLy/UcNhORsHLPoqrPJ"
}
Starting with specical character just one character
{
    "user_name": "+",
    "user_id": "AIDA47947FC2AA8140B1A",
    "arn": "arn:aws:iam::463762618507:user/+",
    "access_key_id": "Kuk-7OpySZuykZS7Jl5aUQ",
    "secret_key": "5dMkfImk8cYYZuitjujN2m/voqEoZw0fyxfW21Qr"
}
starting with specical character
{
    "user_name": "@+=Valid",
    "user_id": "AIDA9360B49B9ED14D51A",
    "arn": "arn:aws:iam::463762618507:user/@+=Valid",
    "access_key_id": "w79FJUvyQ_SjhIOUgmJ2uA",
    "secret_key": "6u5ZPWboVG0Whx8eLFZEiDTy8waVhCmg9+eWWVgj"
}

Max character 64 
{
    "user_name": "0123456789012345678901234567890123456789012345678901234567890123",
    "user_id": "AIDAAA6A836FD8284AED8",
    "arn": "arn:aws:iam::463762618507:user/0123456789012345678901234567890123456789012345678901234567890123",
    "access_key_id": "ZEt4iio4S4O3dQnE3x8WYQ",
    "secret_key": "nB/T0wzkmQIBJhyziGyzBaB0k4ZsWgPPALK27TjK"
}


Invlaid 
65 Character
POST body
{"user_name": "01234567890123456789012345678901234567890123456789012345678901234",
 "password": "Seagate@1",
 "require_reset": false}

OUTPUT
{
    "error_code": "4099",
    "message": "Invalid request message received.",
    "error_format_args": "Invalid request body: {'user_name': ['Iam username should be between 1-64 Characters.Should contain Alphanumeric - _ @ + = or ,.']}"
}

invalid Character 

POST BODY 
{"user_name": "&",
 "password": "Seagate@1",
 "require_reset": false}
 
 OUTPUT
 {
    "error_code": "4099",
    "message": "Invalid request message received.",
    "error_format_args": "Invalid request body: {'user_name': ['Iam username should be between 1-64 Characters.Should contain Alphanumeric - _ @ + = or ,.']}"
}

Bucket Name Tests
Valid

Minimum 3 character bucket name

POST /api/v1/s3/bucket
BODY {"bucket_name": "xyz"}

OUTPUT
{
    "bucket_name": "xyz",
    "bucket_url": "https://None
	/xyz"
}

With . in bucketname
BODY {"bucket_name": "x.z"}
{
    "bucket_name": "x.z",
    "bucket_url": "https://None/x.z"
}

With - in bucket name
BOdy {"bucket_name": "x-z"}

OUTPUT
{
    "bucket_name": "x-z",
    "bucket_url": "https://None/x-z"
}

Max 63 character bucket name
BODY {"bucket_name": "x0123456789012345678901234567890123456789012345678901234567890z"}

OUTPUT
{
    "bucket_name": "x0123456789012345678901234567890123456789012345678901234567890z",
    "bucket_url": "https://None/x0123456789012345678901234567890123456789012345678901234567890z"
}

Invalid case


More than 64 character

Body {"bucket_name": "x01234567890123456789012345678901234567890123456789012345678901z"}

output

{
    "error_code": "4099",
    "message": "Invalid request body: {'bucket_name': [\"Bucket Name should be between 3-63 Characters long.Should contain either lowercase, numeric, '-' or '.' characters. Not starting or ending with '-' or '.'\"]}"
}

just 2 character 
BODY {"bucket_name": "xz"}

output
{
    "error_code": "4099",
    "message": "Invalid request body: {'bucket_name': [\"Bucket Name should be between 3-63 Characters long.Should contain either lowercase, numeric, '-' or '.' characters. Not starting or ending with '-' or '.'\"]}"
}

Ending with - 
BODY {"bucket_name": "xyz-"}

OUTPUT
{
    "error_code": "4099",
    "message": "Invalid request body: {'bucket_name': [\"Bucket Name should be between 3-63 Characters long.Should contain either lowercase, numeric, '-' or '.' characters. Not starting or ending with '-' or '.'\"]}"
}

Bucket name should not start with xn--
BODY 
{"bucket_name": "xn--yz"}

OUTPUT
{
    "error_code": "4099",
    "message": "Invalid request body: {'bucket_name': [\"Bucket Name cannot start with 'xn--'\"]}"
}

Bucket name cannot be IPv4 address
BODY {"bucket_name": "192.168.5.15"}

OUTPUT
{
    "error_code": "4099",
    "message": "Invalid request body: {'bucket_name': ['Bucket Name cannot be ip v4 format']}"
}





</pre>
Signed-off-by: 
