### PR TITLE
[Cortx 1.0] EOS-14978

### DIFF
--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -447,9 +447,9 @@ class Setup:
 
     def _set_rmq_cluster_nodes(self):
         """
-        This method gets the nodes names of the the rabbitmq cluster and writes
-        in the config.
+        This method gets the nodes names of the the rabbitmq cluster and writes in the config.
         """
+
         nodes = []
         nodes_found = False
         try:
@@ -460,6 +460,12 @@ class Setup:
                         nodes = re.findall(r"rabbit@([-\w]+)", line)
                         nodes_found = True
                 if nodes_found:
+                    break
+                result = re.search(
+                    f"{const.RUNNING_NODES_START_TEXT}.*?{const.RUNNING_NODES_STOP_TEXT}",
+                    cmd_output[0], re.DOTALL)
+                if result is not None:
+                    nodes = re.findall(r"rabbit@([-\w]+)", result.group(0))
                     break
                 time.sleep(2**count)
             if nodes:

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -455,12 +455,14 @@ class Setup:
         try:
             for count in range(0, const.RMQ_CLUSTER_STATUS_RETRY_COUNT):
                 cmd_output = Setup._run_cmd(const.RMQ_CLUSTER_STATUS_CMD)
+                # The code below is used to parse RMQ 3.3.5 "cluster_status" command output
                 for line in cmd_output[0].split('\n'):
                     if const.RUNNING_NODES in line:
                         nodes = re.findall(r"rabbit@([-\w]+)", line)
                         nodes_found = True
                 if nodes_found:
                     break
+                # The code below is used to parse CLI output for RMQ 3.8.9 or above
                 result = re.search(
                     f"{const.RUNNING_NODES_START_TEXT}.*?{const.RUNNING_NODES_STOP_TEXT}",
                     cmd_output[0], re.DOTALL)

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -59,6 +59,8 @@ EXCLUDED_COMMANDS = ['csm_setup']
 HIDDEN_COMMANDS = ["bundle_generate", "csm_bundle_generate",]
 RMQ_CLUSTER_STATUS_CMD = 'rabbitmqctl cluster_status'
 RUNNING_NODES = 'running_nodes'
+RUNNING_NODES_START_TEXT = 'Running Nodes'
+RUNNING_NODES_STOP_TEXT = 'Versions'
 
 # CSM Agent Port
 CSM_AGENT_HOST = "localhost"


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any):
</pre>
EOS-14978
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
rabbitmq-server cluster_status command output has been changed between 3.7 and 3.8.9-1.
</pre>
## Solution
<pre>
Adopt parsing code accordingly. 
</pre>
## Unit Test Cases
<pre>
No
</pre>
Signed-off-by: 
