### PR TITLE
EOS-15184 Fxing Log Level in Error Messages for Support Bundle.

### DIFF
--- a/csm/cli/support_bundle/bundle_generate.py
+++ b/csm/cli/support_bundle/bundle_generate.py
@@ -79,6 +79,7 @@ class ComponentsBundle:
             output, err, return_code = cmd_proc.run()
             Log.debug(f"Command Output -> {output} {err}, {return_code}")
             if return_code != 0:
+                Log.error(f"Command Output -> {output} {err}, {return_code}")
                 ComponentsBundle.publish_log(
                     f"Bundle generation failed for {component}", ERROR,
                     bundle_id, node_name, comment)


### PR DESCRIPTION
Signed-off-by: Prathamesh Rodi <prathamesh.rodi@seagate.com>
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any):EOS-15184
    Support bundle generation failed for provisioner and health_map
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
   Logs for Error were displayed under Debug.
  </code>
</pre>
## Solution
<pre>
  <code>
    Added a Log Error Line to Print Log when logger is in INFO Level.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Local Testing Done
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    NA
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
    NA
  </code>
</pre>
## CLI Command Output
<pre>
  <code>
    NA
  </code>
</pre>
