### PR TITLE
EOS-15306 Support Bundle Fix for Motr Path change

### DIFF
--- a/csm/cli/schema/bundle_generate.json
+++ b/csm/cli/schema/bundle_generate.json
@@ -28,7 +28,7 @@
         "csm",
         "sspl",
         "s3server",
-        "core",
+        "motr",
         "hare",
         "provisioner",
         "os",

--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -14,6 +14,13 @@
           "help": "Specify the Reason for Generating Support Bundle."
         },
         {
+          "flag": "--os",
+          "action": "store_const",
+          "help": "Generate Only OS Logs",
+          "default": "false",
+          "const": "true"
+        },
+        {
           "flag": "-c",
           "dest": "components",
           "type": "str",
@@ -25,6 +32,7 @@
             "motr",
             "hare",
             "provisioner",
+            "os",
             "health_map",
             "manifest",
             "uds",

--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -29,7 +29,7 @@
             "csm",
             "sspl",
             "s3server",
-            "core",
+            "motr",
             "hare",
             "provisioner",
             "os",

--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -14,13 +14,6 @@
           "help": "Specify the Reason for Generating Support Bundle."
         },
         {
-          "flag": "--os",
-          "action": "store_const",
-          "help": "Generate Only OS Logs",
-          "default": "false",
-          "const": "true"
-        },
-        {
           "flag": "-c",
           "dest": "components",
           "type": "str",
@@ -32,7 +25,6 @@
             "motr",
             "hare",
             "provisioner",
-            "os",
             "health_map",
             "manifest",
             "uds",

--- a/schema/commands.yaml
+++ b/schema/commands.yaml
@@ -25,8 +25,8 @@ COMMANDS:
     - '<CORTX_PATH>/sspl/conf/setup.yaml'
   s3server:
     - '<CORTX_PATH>/s3/conf/setup.yaml'
-  core:
-    - '<CORTX_PATH>/core/conf/setup.yaml'
+  motr:
+    - '<CORTX_PATH>/motr/conf/setup.yaml'
   hare:
     - '<CORTX_PATH>/hare/conf/setup.yaml'
     - '<CORTX_PATH>/hare/conf/setup-ha.yaml'


### PR DESCRIPTION
Signed-off-by: Prathamesh Rodi <prathamesh.rodi@seagate.com>
# CLI

## Problem Statement
<pre>
  <code>
  Story Ref (if any): EOS-15306
    Motr logs not present in support bundle
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  Yes
  </code>
</pre>
## Problem Description
<pre>
  <code>
    Motr Logs are not present in Support Bundle.
  </code>
</pre>
## Solution
<pre>
  <code>
   Motr setup.yaml files path was updated and hence the file path is updated now.
  </code>
</pre>
## Unit Test Cases
<pre>
  <code>
    Unit Testing details here...
  </code>
</pre>
## CLI Document Updated 
* [File Link](https://seagatetechnology-my.sharepoint.com/:x:/g/personal/prathamesh_rodi_seagate_com/EVRDDBTuaF5EvabmU3XDWOIBCm6NhIPpYo1ShcnAXUFzag?e=XfH7F2)
<pre>
  <code>
    Yes/No
  </code>
</pre>
## Command Help Section 
<pre>
  <code>
    Update Cli Command Help Section....
  </code>
</pre>
## CLI Command Output
<pre>
  <code>
    Update Cli Expected Output Here.... 
  </code>
</pre>
