### PR TITLE
Os logs removal

### DIFF
--- a/csm/cli/schema/bundle_generate.json
+++ b/csm/cli/schema/bundle_generate.json
@@ -28,7 +28,7 @@
         "csm",
         "sspl",
         "s3server",
-        "core",
+        "motr",
         "hare",
         "provisioner",
         "os",

--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -14,6 +14,13 @@
           "help": "Specify the Reason for Generating Support Bundle."
         },
         {
+          "flag": "--os",
+          "action": "store_const",
+          "help": "Generate Only OS Logs",
+          "default": "false",
+          "const": "true"
+        },
+        {
           "flag": "-c",
           "dest": "components",
           "type": "str",
@@ -25,6 +32,7 @@
             "motr",
             "hare",
             "provisioner",
+            "os",
             "health_map",
             "manifest",
             "uds",

--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -29,7 +29,7 @@
             "csm",
             "sspl",
             "s3server",
-            "core",
+            "motr",
             "hare",
             "provisioner",
             "os",

--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -14,13 +14,6 @@
           "help": "Specify the Reason for Generating Support Bundle."
         },
         {
-          "flag": "--os",
-          "action": "store_const",
-          "help": "Generate Only OS Logs",
-          "default": "false",
-          "const": "true"
-        },
-        {
           "flag": "-c",
           "dest": "components",
           "type": "str",
@@ -32,7 +25,6 @@
             "motr",
             "hare",
             "provisioner",
-            "os",
             "health_map",
             "manifest",
             "uds",

--- a/schema/commands.yaml
+++ b/schema/commands.yaml
@@ -25,8 +25,8 @@ COMMANDS:
     - '<CORTX_PATH>/sspl/conf/setup.yaml'
   s3server:
     - '<CORTX_PATH>/s3/conf/setup.yaml'
-  core:
-    - '<CORTX_PATH>/core/conf/setup.yaml'
+  motr:
+    - '<CORTX_PATH>/motr/conf/setup.yaml'
   hare:
     - '<CORTX_PATH>/hare/conf/setup.yaml'
     - '<CORTX_PATH>/hare/conf/setup-ha.yaml'


### PR DESCRIPTION
# CLI

## Problem Statement
<pre>
Story Ref (if any):
SOS Reports are not present in support bundle
</pre>
## Unit testing on RPM done
<pre>
Yes/No
</pre>
## Problem Description
<pre>
SOS reports are not present in support bundle on CENTOS systems.
</pre>
## Solution
<pre>
Removed --os option from support bundle.
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: 
