### PR TITLE
EOS-15351: Fixed delay in stopping CSM that caused STONITH

### DIFF
--- a/csm/core/services/alerts.py
+++ b/csm/core/services/alerts.py
@@ -663,7 +663,7 @@ class AlertMonitorService(Service, Observable):
             Log.info("Stopping Alert monitor thread")
             self._alert_plugin.stop()
             Log.info("Joining Alert monitor thread")
-            self._monitor_thread.join()
+            self._monitor_thread.join(timeout=2.0)
             self._thread_started = False
             self._thread_running = False
             Log.info("Stopped Alert monitor thread")

--- a/csm/core/services/health.py
+++ b/csm/core/services/health.py
@@ -649,7 +649,7 @@ class HealthMonitorService(Service, Observable):
             Log.info("Stopping Health monitor thread")
             self._health_plugin.stop()
             Log.info("Joining Health monitor thread")
-            self._monitor_thread.join()
+            self._monitor_thread.join(timeout=2.0)
             self._thread_started = False
             self._thread_running = False
             Log.info("Stopped Health monitor thread")


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
BUILD# 515 CSM doesn't stop causing STONITH
Story Ref (if any): https://jts.seagate.com/browse/EOS-15351
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
There was a delay of more than 100 seconds to stop csm agent which is causing STONITH
</pre>
## Solution
<pre>
The alert monitor thread seems to be busy with processing alerts at the same time stop of the thread called causing thread not to join. So, added a timeout of 2 seconds for thread to join.
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: pawan.kumarsrivastava@seagate.com
