### PR TITLE
EOS-15653: Re-enable UDS/HAproxy config

### DIFF
--- a/csm/cli/schema/csm_setup.json
+++ b/csm/cli/schema/csm_setup.json
@@ -145,6 +145,11 @@
                   "nargs": "?"
                 },
                 {
+                    "flag": "--uds-public-ip",
+                    "default": null,
+                    "help": "UDS public IP"
+                },
+                {
                     "flag": "args",
                     "default": [],
                     "suppress_help": true,

--- a/csm/common/conf.py
+++ b/csm/common/conf.py
@@ -54,6 +54,15 @@ class Conf:
         Conf._payloads[index].set(key, val)
 
     @staticmethod
+    def delete(index, key):
+        '''Deletes an entry from the configuration according to its key.
+
+        :param key: Key to be deleted
+        :return: Deleted value
+        '''
+        return Conf._payloads[index].pop(key, None)
+
+    @staticmethod
     def save(index=None):
         indexes = [x for x in Conf._payloads.keys()] if index is None else [index]
         for index in indexes:

--- a/csm/common/payload.py
+++ b/csm/common/payload.py
@@ -215,6 +215,19 @@ class Payload:
         self._set(key, val, self._data)
         self._dirty = True
 
+    def pop(self, key, *defaultvalue):
+        k = key.split('.', 1)
+        if len(k) == 1:
+            dirty = k[0] in self._data
+            value = self._data.pop(k[0], *defaultvalue)
+        else:
+            dirty = k[1] in self._data[k[0]]
+            value = self._data[k[0]].pop(k[1], *defaultvalue)
+            if dirty and not bool(self._data[k[0]]):
+                self._data.pop(k, None)
+        self._dirty = dirty
+        return value
+
     def convert(self, map, payload):
         """
         Converts 1 Schema to 2nd Schema depending on mapping dictionary.

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -20,6 +20,7 @@ import grp
 import errno
 import shlex
 import json
+from ipaddress import ip_address
 from cortx.utils.log import Log
 from csm.common.conf import Conf
 from csm.common.payload import Yaml
@@ -731,6 +732,9 @@ class CsmSetup(Setup):
         """
         try:
             self._verify_args(args)
+            uds_public_ip = args.get('uds_public_ip')
+            if uds_public_ip is not None:
+                ip_address(uds_public_ip)
             if not self._replacement_node_flag:
                 self.Config.create(args)
             UDSConfigGenerator.apply()

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -41,6 +41,7 @@ from cortx.utils.data.db.db_provider import (DataBaseProvider, GeneralConfig)
 from csm.common.payload import Text
 from cortx.utils.product_features import unsupported_features
 from csm.conf.salt import SaltWrappers
+from csm.conf.uds import UDSConfigGenerator
 
 # try:
 #     from salt import client
@@ -732,6 +733,7 @@ class CsmSetup(Setup):
             self._verify_args(args)
             if not self._replacement_node_flag:
                 self.Config.create(args)
+            UDSConfigGenerator.apply()
         except Exception as e:
             raise CsmSetupError(f"csm_setup config failed. Error: {e} - {str(traceback.print_exc())}")
 
@@ -794,6 +796,7 @@ class CsmSetup(Setup):
                 self._config_user_permission(reset=True)
                 self.Config.delete()
                 self._config_user(reset=True)
+                UDSConfigGenerator.delete()
             else:
                 self.Config.reset()
                 self.ConfigServer.restart()

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -737,7 +737,8 @@ class CsmSetup(Setup):
                 ip_address(uds_public_ip)
             if not self._replacement_node_flag:
                 self.Config.create(args)
-            UDSConfigGenerator.apply()
+            self.Config.load()
+            UDSConfigGenerator.apply(uds_public_ip=uds_public_ip)
         except Exception as e:
             raise CsmSetupError(f"csm_setup config failed. Error: {e} - {str(traceback.print_exc())}")
 

--- a/csm/conf/uds.py
+++ b/csm/conf/uds.py
@@ -153,7 +153,7 @@ backend uds-backend
 
     @classmethod
     def remove_uds_config(cls):
-        rmtree(cls.UDS_CONFIG_DIR, ignore_errors=True)
+        rmtree(cls.UDS_CONFIG_DIR)
 
     @classmethod
     def apply(cls):

--- a/csm/core/services/usl.py
+++ b/csm/core/services/usl.py
@@ -19,6 +19,7 @@ import time
 from aiohttp import ClientSession, TCPConnector
 from aiohttp import ClientError as HttpClientError
 from boto.s3.bucket import Bucket
+from ipaddress import ip_address
 from random import SystemRandom
 from marshmallow import ValidationError
 from marshmallow.validate import URL
@@ -484,21 +485,39 @@ class UslService(ApplicationService):
             raise CsmNotFoundError(reason)
         return material
 
+    async def _get_public_ip(self) -> str:
+        """
+        Reads UDS public IP from global index in an attempt to override UDS default behavior.
+        If it is not found, uses cluster IP as UDS public IP.
+
+        :return: A string representing UDS public IP address.
+        """
+        try:
+            ip = Conf.get(const.CSM_GLOBAL_INDEX, 'UDS.public_ip')
+            ip_address(ip)
+            return ip
+        except ValueError as e:
+            reason = 'UDS public IP override failed---following usual code path'
+            Log.debug(f'{reason}. Error: {e}')
+        try:
+            conf = await self._provisioner.get_network_configuration()
+            ip = conf.cluster_ip
+            ip_address(ip)
+            return ip
+        except (ValueError, NetworkConfigFetchError) as e:
+            reason = 'Could not obtain network configuration from provisioner'
+            Log.error(f'{reason}: {e}')
+            raise CsmInternalError(reason) from e
+
     async def get_network_interfaces(self) -> List[Dict[str, Any]]:
         """
-        Provides a list of all network interfaces in a system.
+        Provides a list of network interfaces to be advertised by UDS.
 
         :return: A list containing dictionaries, each containing information about a specific
             network interface.
         """
         try:
-            conf = await self._provisioner.get_network_configuration()
-            ip = conf.cluster_ip
-        except NetworkConfigFetchError as e:
-            reason = 'Could not obtain network configuration from provisioner'
-            Log.error(f'{reason}: {e}')
-            raise CsmInternalError(reason) from e
-        try:
+            ip = await self._get_public_ip()
             iface_data = get_interface_details(ip)
         except (ValueError, RuntimeError) as e:
             reason = f'Could not obtain interface details from address {ip}'

--- a/csm/core/services/usl.py
+++ b/csm/core/services/usl.py
@@ -493,7 +493,7 @@ class UslService(ApplicationService):
         """
         try:
             conf = await self._provisioner.get_network_configuration()
-            ip = conf.mgmt_vip
+            ip = conf.cluster_ip
         except NetworkConfigFetchError as e:
             reason = 'Could not obtain network configuration from provisioner'
             Log.error(f'{reason}: {e}')


### PR DESCRIPTION
# Backend

## Problem Statement

[EOS-14470: Configure UDS/HAproxy config from `csm_setup`](https://jts.seagate.com/browse/EOS-14470)
[EOS-15653: Re-enable UDS/HAproxy config](https://jts.seagate.com/browse/EOS-15653)

See ticket for details.

## Unit testing on RPM done

Yes.

## Problem Description

See ticket for details.

## Solution

- Revert changes which disabled UDS data movement over data network
- Add new HAproxy frontend entry on management VIP for UDS
  * Loosen restrictions on the number of minions during HAproxy config step; it required two minions, which didn't work on VM setups
- Provide a configuration option, namely `UDS.public_ip`, which allows USL to override its dependency on cluster IP to derive network interface details for `GET /usl/v1/system/network/interfaces`.

[_Edit Dec/21/2020_]

- Add new option to `csm_setup config`, `--uds-public-ip`, to allow for semi-automatic UDS public IP configuration.

## Unit Test Cases

- `csm_setup config` will update HAproxy system config file
- `csm_setup config` will also create `/var/lib/uds/.uds/uds-config.json` with owner `uds` and group `uds`, and umask `077`.
- After the configuration updates, both HAproxy and UDS will be restarted.
- UDS should then be available on the endpoints listed below. One can test it by invoking `curl -k https://<endpoint>:5000/uds/v1/device`.
  * Private data IP
  * Cluster IP
  * Management VIP
  * `127.0.0.1`
  * `::1`
- CSM agent should return the correct registration status on the `GET /usl/v1/registerDevice` endpoint, i.e., it should be able to contact UDS and return either 200 or 404 as a status code. Bear in mind that this endpoint requires CSM authentication.
- `GET /usl/v1/system/network/interfaces` should return cluster IP network interface details in case `UDS.public_ip` does not return a valid IP address
-  `GET /usl/v1/system/network/interfaces` should return network interface details relative to the IPv4 address configured via `UDS.public_ip`.
  * Have in mind that any changes to `UDS.public_ip` will require `csm_agent` to be restarted before being brought into effect.