### PR TITLE
[cortx-1.0] EOS-16166: HAproxy config on inactive node fails because management IP is not assigned to it

### DIFF
--- a/csm/conf/uds.py
+++ b/csm/conf/uds.py
@@ -72,7 +72,6 @@ class UDSConfigGenerator:
     @staticmethod
     def generate_haproxy_frontend_config():
         cluster_ip = SaltWrappers.get_salt_call('pillar.get', 'cluster:cluster_ip')
-        mgmt_vip = SaltWrappers.get_salt_call('pillar.get', 'cluster:mgmt_vip')
         return f"""\
 frontend uds-frontend
     mode tcp
@@ -80,7 +79,6 @@ frontend uds-frontend
     bind 127.0.0.1:5000
     bind ::1:5000
     bind {cluster_ip}:5000
-    bind {mgmt_vip}:5000
     acl udsbackendacl dst_port 5000
     use_backend uds-backend if udsbackendacl\
 """
@@ -205,8 +203,12 @@ backend uds-backend
     @classmethod
     def apply(cls, uds_public_ip):
         cls.update_csm_config(uds_public_ip)
-        cls.update_haproxy_config()
-        cls.update_uds_config()
+        if uds_public_ip is None:
+            cls.update_haproxy_config()
+            cls.update_uds_config()
+        else:
+            cls.remove_haproxy_config()
+            cls.remove_uds_config()
 
     @classmethod
     def delete(cls):

--- a/csm/conf/uds.py
+++ b/csm/conf/uds.py
@@ -17,6 +17,7 @@ from csm.common.conf import Conf
 from csm.conf.salt import SaltWrappers
 from csm.core.blogic import const
 
+from ipaddress import ip_address
 from pathlib import Path
 from pwd import getpwnam
 from shutil import copyfile, rmtree
@@ -72,6 +73,7 @@ class UDSConfigGenerator:
     @staticmethod
     def generate_haproxy_frontend_config():
         cluster_ip = SaltWrappers.get_salt_call('pillar.get', 'cluster:cluster_ip')
+        ip_address(cluster_ip)
         return f"""\
 frontend uds-frontend
     mode tcp


### PR DESCRIPTION
# Backend

## Problem Statement

[EOS-14470: Configure UDS/HAproxy config from `csm_setup`](https://jts.seagate.com/browse/EOS-14470)
[EOS-16166: HAproxy config on inactive node fails because management IP is not assigned to it](https://jts.seagate.com/browse/EOS-16166)

See tickets for details.

## Unit testing on RPM done

Yes.

## Problem Description

See tickets for details.

## Solution

Add `transparent` option to HA proxy `bind` config for the management VIP.

## Unit Test Cases

Should be tested in conjunction with EOS-14470 ([see PR](https://github.com/Seagate/cortx-manager/pull/330)). Additionally to its test cases, we must ensure that HAproxy configuration on both nodes is successful and its respective services run with no issues.