### PR TITLE
Eos:16689-Removed user deletion logic from csm_setup post_update

### DIFF
--- a/csm/conf/salt.py
+++ b/csm/conf/salt.py
@@ -30,7 +30,9 @@ class SaltWrappers:
         if on_salt_error not in ('raise', 'log'):
             raise ValueError(f'Invalid argument: on_salt_error={on_salt_error}')
         try:
-            process = SimpleProcess(f"salt-call {method} {key} --out=json")
+            salt_cmd = f"salt-call {method} {key} --out=json"
+            Log.info(f"Executing salt-call: {salt_cmd}")
+            process = SimpleProcess(salt_cmd)
             stdout, stderr, rc = process.run()
         except Exception as e:
             desc = f'Error in command execution : {e}'
@@ -53,6 +55,7 @@ class SaltWrappers:
         try:
             minion_arg = '*' if minion_id is None else minion_id
             cmd = f'salt {minion_arg} {method} {key} --out=json --static'
+            Log.info(f"Executing salt command: {cmd}")
             process = SimpleProcess(cmd)
             stdout, stderr, rc = process.run()
         except Exception as e:

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -35,6 +35,7 @@ import re
 import time
 import traceback
 import asyncio
+import subprocess
 from csm.core.blogic.models.alerts import AlertModel
 from csm.core.services.alerts import AlertRepository
 from cortx.utils.schema.payload import Json
@@ -888,13 +889,11 @@ class CsmSetup(Setup):
         Execute 'csm_setup post_update' mannually once system is updated using SW update.
         """
         try:
-            import subprocess
             Log.info(f"Triggering csm_setup post_update: {args}")
             if self._is_user_exist():
                 csm_passwd = self._fetch_csm_user_password(decrypt=True)
                 cmd = (f"bash -c \"echo -e '{csm_passwd}\\n{csm_passwd}' | passwd {self._user}\"")
                 Log.info(f"Executing command: {cmd}")
-                # sp = SimpleProcess(cmd)
                 subprocess.check_call(cmd,shell=True)
                 Log.info("Ended with cmd execution!!!")
                 Setup.Config.delete()

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -888,14 +888,15 @@ class CsmSetup(Setup):
         Execute 'csm_setup post_update' mannually once system is updated using SW update.
         """
         try:
+            import subprocess
             Log.info(f"Triggering csm_setup post_update: {args}")
             if self._is_user_exist():
                 csm_passwd = self._fetch_csm_user_password(decrypt=True)
-                cmd = (f"bash -c \"echo -e "
-                   f"'{csm_passwd}\\n{csm_passwd}' | passwd {self._user}\"")
+                cmd = (f"bash -c \"echo -e '{csm_passwd}\\n{csm_passwd}' | passwd {self._user}\"")
                 Log.info(f"Executing command: {cmd}")
-                sp = SimpleProcess(cmd)
-                sp.run(shell=True)
+                # sp = SimpleProcess(cmd)
+                subprocess.check_call(cmd,shell=True)
+                Log.info("Ended with cmd execution!!!")
                 Setup.Config.delete()
                 Log.info("Applying salt state post update")
                 SaltWrappers.get_salt_call("state.apply", "components.system.config.pillar_encrypt")

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -890,14 +890,16 @@ class CsmSetup(Setup):
         try:
             Log.info(f"Triggering csm_setup post_update: {args}")
             if self._is_user_exist():
-                Log.debug(f"Deleting user {self._user}")
                 csm_passwd = self._fetch_csm_user_password(decrypt=True)
                 cmd = (f"bash -c \"echo -e "
                    f"'{csm_passwd}\\n{csm_passwd}' | passwd {self._user}\"")
+                Log.info(f"Executing command: {cmd}")
+                sp = SimpleProcess(cmd)
+                sp.run(shell=True)
                 Setup.Config.delete()
-                Log.debug("Applying salt state post update")
+                Log.info("Applying salt state post update")
                 SaltWrappers.get_salt_call("state.apply", "components.system.config.pillar_encrypt")
-                Log.debug("Executing csm_setup commands")
+                Log.info("Executing csm_setup commands")
                 Setup._run_cmd("csm_setup post_install")
                 Setup._run_cmd("csm_setup config")
                 Setup._run_cmd("csm_setup init")

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -891,6 +891,8 @@ class CsmSetup(Setup):
         try:
             Log.info(f"Triggering csm_setup post_update: {args}")
             if self._is_user_exist():
+                Log.info("Applying salt state post update")
+                SaltWrappers.get_salt_call("state.apply", "components.system.config.pillar_encrypt")
                 csm_passwd = self._fetch_csm_user_password(decrypt=True)
                 if not csm_passwd:
                     Log.error("CSM Password Not Recieved from provisioner.")
@@ -900,8 +902,6 @@ class CsmSetup(Setup):
                 subprocess.check_call(cmd,shell=True)
                 Log.info("Deleting csm config directory")
                 Setup.Config.delete()
-                Log.info("Applying salt state post update")
-                SaltWrappers.get_salt_call("state.apply", "components.system.config.pillar_encrypt")
                 Log.info("Executing csm_setup commands")
                 Setup._run_cmd("csm_setup post_install")
                 Setup._run_cmd("csm_setup config")


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any):CSM: UDX: LR Device registration failed on 565
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
After user deletion in post_update, permissions for udx and csm folders are not updated. Deu to this device registration fails. 
</pre>
## Solution
<pre>
Removed user deletion logic and password obtained from provisioner is updated to user
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: Udayan Yaragattikaar<udayan.yaragattikar@seagate.com>
