### PR TITLE
EOS-16153 Fix for Machine ID Code Conversion.

### DIFF
--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -87,7 +87,7 @@ class Configure(Setup):
         :return:
         """
         Log.error("Creating CSM Conf File on Required Location.")
-        if not self._is_env_vm:
+        if self._is_env_vm:
             Conf.set(const.CSM_GLOBAL_INDEX, f"{const.DEPLOYMENT}>{const.MODE}",
                      const.DEV)
         self.store_encrypted_password()

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -166,7 +166,7 @@ class Setup:
         machine_id, _err, _returncode = proc_obj.run()
         if _returncode != 0:
             raise CsmSetupError('Unable to obtain current machine id.')
-        return machine_id
+        return (machine_id.decode("utf-8")).replace("\n", "")
 
     @staticmethod
     def _is_group_exist(user_group):


### PR DESCRIPTION
Signed-off-by: Prathamesh Rodi <prathamesh.rodi@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any): EOS-16153
CSM Mini Provisioner 
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
CSM Setup Configure Failed due to incorrect  vm state  setting.
</pre>
## Solution
<pre>
Fixed If Statement in the Code as well as Machine-ID removed \n
</pre>
## Unit Test Cases
<pre>
Tested Manually.
</pre>