### PR TITLE
EOS-17010 Updating setup.yaml for CSM Mini Provisioner Integration

### DIFF
--- a/csm/conf/setup.yaml
+++ b/csm/conf/setup.yaml
@@ -15,16 +15,16 @@
 
 csm:
     post_install:
-        script: /usr/bin/csm_setup
-        args: post_install
+        script: /usr/bin/csm_setup post_install
+        args: --config <URL>
 
     init:
-        script: /usr/bin/csm_setup
-        args: init
+        script: /usr/bin/csm_setup init
+        args: --config <URL>
 
     config:
-        script: /usr/bin/csm_setup
-        args: config
+        script: /usr/bin/csm_setup config
+        args: --config <URL>
 
     test:
         script: /usr/bin/csm_test
@@ -39,9 +39,8 @@ csm:
             - -f <CSM_PATH>/test/test_data/args.yaml
 
     reset:
-        script: /usr/bin/csm_setup
-        args:
-            - reset --hard
+        script: /usr/bin/csm_setup reset
+        args: --config <URL>
 
     ha:
         script: /opt/seagate/cortx/ha/conf/script/build-ha-csm
@@ -54,13 +53,13 @@ csm:
 
     backup:
         files:
-            - /etc/csm/csm.conf 
-            - /etc/csm/database.yaml 
+            - /etc/csm/csm.conf
+            - /etc/csm/database.yaml
             - /etc/csm/components.yaml
             - /etc/csm/cluster.conf
             - /etc/ssl/stx/stx.pem
 
     refresh_config:
-        script: /usr/bin/csm_setup
-        args: refresh_config
+        script: /usr/bin/csm_setup refresh_config
+        args: --config <URL>
 


### PR DESCRIPTION
# Backend
## Problem Statement
<pre>
Story Ref (if any): EOS-17010
CSM Mini-Provisioner Integration with Provisioner.
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
Need to Integrate CSM Mini Provisoner with Provisioner API to be able to Deploy on Single Node VM Instance.
</pre>
## Solution
<pre>
Changes made in setup.yaml that is called by Provisioner to Implement while Intallation.
</pre>
## Unit Test Cases
<pre>
This will be tested with provisioner while Setup.
</pre>
Signed-off-by: 
