### PR TITLE
EOS-17586: Modified SSL certificate expiry IEM message

### DIFF
--- a/csm/core/services/security.py
+++ b/csm/core/services/security.py
@@ -326,13 +326,14 @@ class SecurityService(ApplicationService):
             expiry_time_ltz = await self._local_timezone(expiry_time)
             days_left = (expiry_time.date() - current_time.date()).days
             if expiry_time < current_time:
-                message = f'SSL certificate expired at {expiry_time_ltz}'
+                message = f'SSL certificate expired at {expiry_time_ltz}.'
             elif days_left in warning_days:
-                message = f'SSL certificate expires at {expiry_time_ltz} - {days_left} day(s) left'
+                message = f'SSL certificate expires at {expiry_time_ltz} - {days_left} day(s) left.'
             else:
                 message = None
 
             if message:
+                message += ' Please refer user guide on how to update the certificate.'
                 Log.warn(f'{message}')
                 Iem.generate(Iem.SEVERITY_WARN,
                              Iem.IEC_CSM_SECURITY_SSL_CERT_EXPIRING,


### PR DESCRIPTION
Signed-off-by: Pawan Kumar Srivastava <pawan.kumarsrivastava@seagate.com>

# Backend

## Problem Statement
Modified SSL certificate expiry IEM message
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-17586
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
More informative message is required for SSL certificate expiry message.
</pre>
## Solution
<pre>
Added the more informative message for SSL certificate expiry message
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: pawan.kumarsrivastva@seagate.com
