### PR TITLE
EOS-17506: S3 use cases should be working on VM through CSM (BE)

### DIFF
--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -159,6 +159,7 @@ class CsmAgent:
         CsmRestApi._app[const.S3_ACCOUNT_SERVICE] = S3AccountService(s3)
         CsmRestApi._app[const.S3_BUCKET_SERVICE] = S3BucketService(s3)
         CsmRestApi._app[const.S3_ACCESS_KEYS_SERVICE] = S3AccessKeysService(s3)
+        CsmRestApi._app[const.S3_SERVER_INFO_SERVICE] = S3ServerInfoService(provisioner)
 
         user_service = CsmUserService(provisioner, user_manager)
         CsmRestApi._app[const.CSM_USER_SERVICE] = user_service
@@ -249,6 +250,7 @@ if __name__ == '__main__':
     from csm.core.services.s3.accounts import S3AccountService
     from csm.core.services.s3.buckets import S3BucketService
     from csm.core.services.s3.access_keys import S3AccessKeysService
+    from csm.core.services.s3.server_info import S3ServerInfoService
     from csm.core.services.usl import UslService
     from csm.core.services.users import CsmUserService, UserManager
     from csm.core.services.roles import RoleManagementService, RoleManager

--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -155,9 +155,9 @@ class CsmAgent:
 
         # S3 Plugin creation
         s3 = import_plugin_module(const.S3_PLUGIN).S3Plugin()
-        CsmRestApi._app[const.S3_IAM_USERS_SERVICE] = IamUsersService(s3, provisioner)
-        CsmRestApi._app[const.S3_ACCOUNT_SERVICE] = S3AccountService(s3, provisioner)
-        CsmRestApi._app[const.S3_BUCKET_SERVICE] = S3BucketService(s3, provisioner)
+        CsmRestApi._app[const.S3_IAM_USERS_SERVICE] = IamUsersService(s3)
+        CsmRestApi._app[const.S3_ACCOUNT_SERVICE] = S3AccountService(s3)
+        CsmRestApi._app[const.S3_BUCKET_SERVICE] = S3BucketService(s3)
         CsmRestApi._app[const.S3_ACCESS_KEYS_SERVICE] = S3AccessKeysService(s3)
 
         user_service = CsmUserService(provisioner, user_manager)

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -443,6 +443,7 @@ S3_ACCOUNT_SERVICE = "s3_account_service"
 S3_IAM_USERS_SERVICE = "s3_iam_users_service"
 S3_BUCKET_SERVICE = "s3_bucket_service"
 S3_ACCESS_KEYS_SERVICE = 's3_access_keys_service'
+S3_SERVER_INFO_SERVICE = 's3_server_info_service'
 APPLIANCE_INFO_SERVICE = "appliance_info_service"
 SYSTEM_STATUS_SERVICE = "system_status_service"
 

--- a/csm/core/controllers/routes.py
+++ b/csm/core/controllers/routes.py
@@ -29,6 +29,7 @@ from csm.core.blogic.storage import SyncInMemoryKeyValueStorage
 from csm.core.controllers.s3.access_keys import S3AccessKeysListView, S3AccessKeysView  # noqa: F401
 from csm.core.controllers.s3.iam_users import IamUserView,  IamUserListView
 from csm.core.controllers.s3.buckets import S3BucketListView, S3BucketView, S3BucketPolicyView
+from csm.core.controllers.s3.server_info import S3ServerInfoView
 from csm.core.controllers.security import (SecurityInstallView, SecurityStatusView,
                                            SecurityUploadView, SecurityDetailsView)
 from csm.core.controllers.maintenance import MaintenanceView

--- a/csm/core/controllers/s3/server_info.py
+++ b/csm/core/controllers/s3/server_info.py
@@ -1,0 +1,39 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+from csm.common.service_urls import ServiceUrls
+from csm.core.blogic import const
+from csm.core.controllers.view import CsmView
+from cortx.utils.log import Log
+
+@CsmView._app_routes.view("/api/v1/s3")
+class S3ServerInfoView(CsmView):
+    """
+    S3 Server Info View for GET REST API implementation:
+        - Get information about the S3 server
+    """
+
+    def __init__(self, request):
+        super().__init__(request, const.S3_SERVER_INFO_SERVICE)
+
+    async def get(self):
+        """
+        GET REST implementation for S3 server information request
+
+        :return:
+        """
+        Log.debug(f"Handling list s3 buckets fetch request."
+                  f" user_id: {self.request.session.credentials.user_id}")
+        return await self._service.get_s3_server_info()

--- a/csm/core/services/s3/accounts.py
+++ b/csm/core/services/s3/accounts.py
@@ -17,7 +17,6 @@ from typing import Dict
 
 from csm.core.blogic import const
 from cortx.utils.conf_store.conf_store import Conf
-from csm.common.service_urls import ServiceUrls
 from cortx.utils.log import Log
 from csm.common.errors import CsmInternalError, CsmNotFoundError
 from csm.common.services import ApplicationService
@@ -31,15 +30,13 @@ class S3AccountService(S3BaseService):
     """
     Service for S3 account management
     """
-    def __init__(self, s3plugin, provisioner):
+    def __init__(self, s3plugin):
         """
         Initialize S3AccountService.
 
         :param s3plugin: S3 plugin object.
-        :param provisioner: provisioner object.
         """
         self._s3plugin = s3plugin
-        self._provisioner = provisioner
         #TODO
         """
         Password should be taken as input and not read from conf file directly.
@@ -140,10 +137,8 @@ class S3AccountService(S3BaseService):
                         }
                     )
                     break
-        service_urls = ServiceUrls(self._provisioner)
         resp = {
             "s3_accounts": accounts_list,
-            "s3_urls": await service_urls.get_s3_uris()
         }
         if accounts.is_truncated:
             resp["continue"] = accounts.marker

--- a/csm/core/services/s3/buckets.py
+++ b/csm/core/services/s3/buckets.py
@@ -19,7 +19,6 @@ from botocore.exceptions import ClientError
 from boto.s3.bucket import Bucket
 
 from cortx.utils.log import Log
-from csm.common.service_urls import ServiceUrls
 
 from csm.plugins.cortx.s3 import S3Plugin, S3Client
 from csm.core.providers.providers import Response
@@ -33,10 +32,9 @@ class S3BucketService(S3BaseService):
     Service for S3 account management
     """
 
-    def __init__(self, s3plugin: S3Plugin, provisioner):
+    def __init__(self, s3plugin: S3Plugin):
         self._s3plugin = s3plugin
         self._s3_connection_config = CsmS3ConfigurationFactory.get_s3_connection_config()
-        self._provisioner = provisioner
 
     async def get_s3_client(self, s3_session: S3Credentials) -> S3Client:
         """
@@ -71,13 +69,8 @@ class S3BucketService(S3BaseService):
         except ClientError as e:
             # TODO: distinguish errors when user is not allowed to get/delete/create buckets
             self._handle_error(e)
-        service_urls = ServiceUrls(self._provisioner)
-        bucket_url = await service_urls.get_bucket_url(bucket_name, 'https')
-        s3_uri = await service_urls.get_s3_uri(scheme='s3')
         return {
             "bucket_name": bucket_name,
-            "bucket_url": bucket_url,
-            "s3_uri": s3_uri,
         }  # bucket Can be None
 
     @Log.trace_method(Log.INFO)
@@ -98,13 +91,10 @@ class S3BucketService(S3BaseService):
             # TODO: distinguish errors when user is not allowed to get/delete/create buckets
             self._handle_error(e)
 
-        service_urls = ServiceUrls(self._provisioner)
         # TODO: create model for response
         bucket_list = [
             {
                 "name": bucket.name,
-                "bucket_url": await service_urls.get_bucket_url(bucket.name, 'https'),
-                "s3_uri": await service_urls.get_s3_uri(scheme='s3'),
             }
             for bucket in bucket_list]
         return {"buckets": bucket_list}

--- a/csm/core/services/s3/iam_users.py
+++ b/csm/core/services/s3/iam_users.py
@@ -15,7 +15,6 @@
 
 from typing import Union, Dict
 from cortx.utils.log import Log
-from csm.common.service_urls import ServiceUrls
 from csm.core.data.models.s3 import IamErrors, IamError
 from csm.core.providers.providers import Response
 from csm.core.services.s3.utils import S3BaseService, CsmS3ConfigurationFactory
@@ -27,11 +26,10 @@ class IamUsersService(S3BaseService):
     Service for IAM user management
     """
 
-    def __init__(self, s3plugin, provisioner):
+    def __init__(self, s3plugin):
         self._s3plugin = s3plugin
         # S3 Connection Object.
         self._iam_connection_config = CsmS3ConfigurationFactory.get_iam_connection_config()
-        self._provisioner = provisioner
 
     @Log.trace_method(Log.DEBUG)
     async def fetch_iam_client(self, s3_session: Dict) -> IamClient:
@@ -100,8 +98,6 @@ class IamUsersService(S3BaseService):
         iam_users_list["iam_users"] = [vars(each_user)
                                        for each_user in iam_users_list["iam_users"]
                                        if not vars(each_user)["user_name"] == "root" ]
-        service_urls = ServiceUrls(self._provisioner)
-        iam_users_list["s3_urls"] = await service_urls.get_s3_uris()
         return iam_users_list
 
     @Log.trace_method(Log.DEBUG, exclude_args=['user_password'])

--- a/csm/core/services/s3/server_info.py
+++ b/csm/core/services/s3/server_info.py
@@ -1,0 +1,35 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+from csm.common.services import ApplicationService
+from csm.common.service_urls import ServiceUrls
+
+class S3ServerInfoService(ApplicationService):
+    """
+    Service for acessing S3 server information
+    """
+
+    def __init__(self, provisioner):
+        self._provisioner = provisioner
+
+    async def get_s3_server_info(self):
+        """
+        Obtain information about S3 server in json format
+        """
+        service_urls = ServiceUrls(self._provisioner)
+        s3_urls = await service_urls.get_s3_uris()
+        return {
+            "s3_urls": s3_urls
+        }


### PR DESCRIPTION
# Backend

## Problem Statement
Story Ref (if any): [EOS-17506](https://jts.seagate.com/browse/EOS-17506)
## Unit testing on RPM done
Yes
## Problem Description
When the cluster ID is not configured on the system the vast number of S3 REST endpoints stops working.   
## Solution
Failures happen because services apart from accessing the S3 server, try to solicit the cluster ID from the provisioner (not configured) in order to build S3 server's URL and hence the whole request fails.
The solution is to clear S3 services from all the provisioner calls so that S3 REST is responsible for sole resource (S3 server). In order to build S3 server's URL the separate REST endpoint is allocated: GET /api/v1/s3, that could be considered as the description of the system's S3 server.
## Unit Test Cases
Try the affected APIs either from CLI or UI
- create S3 account,
- list S3 accounts,
- create IAM user,
- list IAM users,
- create a bucket,
- list buckets
