### PR TITLE
Update CSM RPM License Information

### DIFF
--- a/cicd/cortxcli.spec
+++ b/cicd/cortxcli.spec
@@ -17,7 +17,7 @@ Name: <RPM_NAME>
 Version: %{version}
 Release: %{dist}
 Summary: Cortx CLI
-License: Seagate Proprietary
+License: Seagate
 URL: http://github.com/Seagate/cortx-manager
 Source0: <PRODUCT>-cli-%{version}.tar.gz
 Requires: <CSM_AGENT_RPM_NAME>

--- a/cicd/csm_agent.spec
+++ b/cicd/csm_agent.spec
@@ -17,7 +17,7 @@ Name: <RPM_NAME>
 Version: %{version}
 Release: %{dist}
 Summary: CSM Tools
-License: Seagate Proprietary
+License: Seagate
 URL: http://github.com/Seagate/cortx-manager
 Source0: <PRODUCT>-csm_agent-%{version}.tar.gz
 %define debug_package %{nil}


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): NA
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
Incorrect License information observed for csm-agent rpm and cortxcli rpm 
</pre>
## Solution
<pre>
Updated correct License information  for csm-agent rpm and cortxcli rpm 
</pre>
## Unit Test Cases
<pre>
[root@ssc-vm-2292 731368]# rpm  -qa --qf "%{name} : %{license}\n" | grep cortx-csm_agent
cortx-csm_agent : Seagate


</pre>
<pre>
[root@ssc-vm-2292 731368]# rpm  -qa --qf "%{name} : %{license}\n" | grep cortx-cli
cortx-cli : Seagate

</pre>

Signed-off-by: Udayan Yaragattikar (udayan.yaragattikar@seagate.com)
