### PR TITLE
[MAIN]EOS-18376:  Check if storage directories are present for file upload, else create

### DIFF
--- a/cicd/pyinstaller/requirment.txt
+++ b/cicd/pyinstaller/requirment.txt
@@ -21,7 +21,7 @@ requests==2.22.0
 pathlib==1.0.1
 statsd==3.2.2
 urllib3==1.25.7
-cryptography==3.2
+cryptography==2.8
 python-crontab==2.5.1
 confluent-kafka==1.5.0
 netifaces==0.10.9

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -116,8 +116,8 @@ class FileRef():
         try:
             copyfile(path_to_cached_file, path_to_file_to_save)
         except PermissionError as pe:
-            Log.warn(f"Incorrect permissions for {path_to_file_to_save}: {pe}.")
-            raise CsmInternalError(f"Incorrect permissions for {path_to_file_to_save}")
+            Log.warn(f"Incorrect permissions for {dir_to_save}: {pe}.")
+            raise CsmInternalError(f"Incorrect permissions for {dir_to_save}")
         
         return path_to_file_to_save
 

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -89,7 +89,10 @@ class FileRef():
         return path_to_cached_file
 
     def save_file(self, dir_to_save, filename, overwrite=False):
-        Log.debug(f"Saving f{filename} at f{dir_to_save}")
+        if not os.path.exists(dir_to_save):
+            Log.warn(f"{dir_to_save} not found. Recreating storage directory." )
+            os.makedirs(dir_to_save, exist_ok=True)
+        Log.info(f"Saving {filename} at {dir_to_save}")
         path_to_cached_file = self.get_file_path()
         path_to_file_to_save = os.path.join(dir_to_save, filename)
 

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -108,6 +108,10 @@ class FileRef():
             Log.warn(f"Incorrect permissions for {path_to_file_to_save}. Changing permissions for USER to RWX: {pe}")
             os.chmod(path_to_file_to_save, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
             copyfile(path_to_cached_file, path_to_file_to_save)
+        except Exception as e:
+            Log.error("Error occured: {e}")
+            copyfile(path_to_cached_file, path_to_file_to_save)
+
 
         return path_to_file_to_save
 

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -106,12 +106,8 @@ class FileRef():
             copyfile(path_to_cached_file, path_to_file_to_save)
         except PermissionError as pe:
             Log.warn(f"Incorrect permissions for {path_to_file_to_save}. Changing permissions for USER to RWX: {pe}")
-            os.chmod(path_to_file_to_save, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+            os.chmod(dir_to_save, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
             copyfile(path_to_cached_file, path_to_file_to_save)
-        except Exception as e:
-            Log.error("Error occured: {e}")
-            copyfile(path_to_cached_file, path_to_file_to_save)
-
 
         return path_to_file_to_save
 

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -99,7 +99,7 @@ class FileRef():
             except Exception as e:
                 Log.debug(f"Can not create directory {e}")
                 raise CsmInternalError(f"System error during directory creation for "
-                                       f"path='{file_cache.cache_dir}': {e}")
+                                       f"path='{dir_to_save}': {e}")
             finally:
                 new_mask = os.umask(original_mask)
                 Log.debug(f"new mask: {new_mask}")

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -93,15 +93,14 @@ class FileRef():
             Log.warn(f"{dir_to_save} not found. Recreating storage directory." )
             try:
                 original_mask = os.umask(0o007)
-                Log.debug(f"original mask: {original_mask}")
+                Log.debug(f"Setting umask value before creating directory: original mask: {original_mask}")
                 os.makedirs(dir_to_save)
             except Exception as e:
                 Log.error(f"Failed to create directory {dir_to_save}: {e}")
                 raise CsmInternalError(f"System error during directory creation for "
                                        f"path='{dir_to_save}': {e}")
             finally:
-                new_mask = os.umask(original_mask)
-                Log.debug(f"new mask: {new_mask}")
+                Log.debug(f"Resetting umask with original value: {os.umask(original_mask)}")
 
         Log.info(f"Saving {filename} at {dir_to_save}")
         path_to_cached_file = self.get_file_path()

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -96,7 +96,7 @@ class FileRef():
                 Log.debug(f"original mask: {original_mask}")
                 os.makedirs(dir_to_save)
             except Exception as e:
-                Log.debug(f"Can not create directory {e}")
+                Log.error(f"Failed to create directory {dir_to_save}: {e}")
                 raise CsmInternalError(f"System error during directory creation for "
                                        f"path='{dir_to_save}': {e}")
             finally:

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -14,6 +14,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 import os
+import stat
 import uuid
 from abc import ABC
 from enum import Enum
@@ -101,8 +102,13 @@ class FileRef():
                 f'File "{path_to_file_to_save}" already exists. Change ' +
                 '"overwrite" argument if you want to overwrite file')
 
-        copyfile(path_to_cached_file, path_to_file_to_save)
-        
+        try:
+            copyfile(path_to_cached_file, path_to_file_to_save)
+        except PermissionError as pe:
+            Log.warn(f"Incorrect permissions for {path_to_file_to_save}. Changing permissions for USER to RWX")
+            os.chmod(path_to_file_to_save, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+            copyfile(path_to_cached_file, path_to_file_to_save)
+
         return path_to_file_to_save
 
 

--- a/csm/core/services/file_transfer.py
+++ b/csm/core/services/file_transfer.py
@@ -105,7 +105,7 @@ class FileRef():
         try:
             copyfile(path_to_cached_file, path_to_file_to_save)
         except PermissionError as pe:
-            Log.warn(f"Incorrect permissions for {path_to_file_to_save}. Changing permissions for USER to RWX")
+            Log.warn(f"Incorrect permissions for {path_to_file_to_save}. Changing permissions for USER to RWX: {pe}")
             os.chmod(path_to_file_to_save, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
             copyfile(path_to_cached_file, path_to_file_to_save)
 

--- a/csm/core/services/firmware_update.py
+++ b/csm/core/services/firmware_update.py
@@ -43,14 +43,17 @@ class FirmwareUpdateService(UpdateService):
         firmware_package_path = package_ref.save_file(self._fw_storage_path, filename, True)
         model = await self._update_repo.get_current_model(const.FIRMWARE_UPDATE_ID)
         if model and model.is_in_progress():
+            Log.error("You cannot upload a new package while there is an ongoing update")
             raise InvalidRequest("You cannot upload a new package while there is an ongoing update")
 
+        Log.debug("Saving model for firmware update")
         model = UpdateStatusEntry.generate_new(const.FIRMWARE_UPDATE_ID)
         model.version = os.path.splitext(os.path.basename(filename))[0]
         model.description = os.path.join(self._fw_storage_path, filename)
         model.file_path = os.path.join(self._fw_storage_path, filename)
         model.details = ''
         model.mark_uploaded()
+        Log.debug(model.to_printable())
         await self._update_repo.save_model(model)
         return model.to_printable()
 

--- a/csm/core/services/firmware_update.py
+++ b/csm/core/services/firmware_update.py
@@ -47,7 +47,7 @@ class FirmwareUpdateService(UpdateService):
             raise CsmInternalError(f'Failed to save the package: {e}')
         model = await self._update_repo.get_current_model(const.FIRMWARE_UPDATE_ID)
         if model and model.is_in_progress():
-            Log.error("You cannot upload a new package while there is an ongoing update")
+            Log.error(f"You cannot upload a new package while there is an ongoing update:{model.to_printable()}")
             raise InvalidRequest("You cannot upload a new package while there is an ongoing update")
 
         model = UpdateStatusEntry.generate_new(const.FIRMWARE_UPDATE_ID)

--- a/csm/core/services/firmware_update.py
+++ b/csm/core/services/firmware_update.py
@@ -40,7 +40,7 @@ class FirmwareUpdateService(UpdateService):
         :param filename: str
         :return: dict
         """
-        try: 
+        try:
             firmware_package_path = package_ref.save_file(self._fw_storage_path, filename, True)
         except Exception as e:
             Log.error(f'Failed to save the package: {e}')
@@ -50,14 +50,13 @@ class FirmwareUpdateService(UpdateService):
             Log.error("You cannot upload a new package while there is an ongoing update")
             raise InvalidRequest("You cannot upload a new package while there is an ongoing update")
 
-        Log.debug("Saving model for firmware update")
         model = UpdateStatusEntry.generate_new(const.FIRMWARE_UPDATE_ID)
         model.version = os.path.splitext(os.path.basename(filename))[0]
         model.description = os.path.join(self._fw_storage_path, filename)
         model.file_path = os.path.join(self._fw_storage_path, filename)
         model.details = ''
         model.mark_uploaded()
-        Log.debug(model.to_printable())
+        Log.debug(f"Saving model for firmware update {model.to_printable()}")
         await self._update_repo.save_model(model)
         return model.to_printable()
 

--- a/csm/core/services/firmware_update.py
+++ b/csm/core/services/firmware_update.py
@@ -40,7 +40,11 @@ class FirmwareUpdateService(UpdateService):
         :param filename: str
         :return: dict
         """
-        firmware_package_path = package_ref.save_file(self._fw_storage_path, filename, True)
+        try: 
+            firmware_package_path = package_ref.save_file(self._fw_storage_path, filename, True)
+        except Exception as e:
+            Log.error(f'Failed to save the package: {e}')
+            raise CsmInternalError(f'Failed to save the package: {e}')
         model = await self._update_repo.get_current_model(const.FIRMWARE_UPDATE_ID)
         if model and model.is_in_progress():
             Log.error("You cannot upload a new package while there is an ongoing update")

--- a/csm/core/services/hotfix_update.py
+++ b/csm/core/services/hotfix_update.py
@@ -48,7 +48,7 @@ class HotfixApplicationService(UpdateService):
 
         model = await self._get_renewed_model(const.SOFTWARE_UPDATE_ID)
         if model and model.is_in_progress():
-            Log.error("You cannot upload a new package while there is an ongoing update")
+            Log.error(f"You cannot upload a new package while there is an ongoing update:{model.to_printable()} ")
             raise InvalidRequest("You cannot upload a new package while there is an ongoing update")
 
         try:

--- a/csm/core/services/hotfix_update.py
+++ b/csm/core/services/hotfix_update.py
@@ -42,8 +42,8 @@ class HotfixApplicationService(UpdateService):
         """
         try:
             info = await self._provisioner.validate_hotfix_package(file_ref.get_file_path(), file_name)
-        except CsmError:
-            Log.error('You have uploaded an invalid software update package')
+        except CsmError as ce:
+            Log.error(f'You have uploaded an invalid software update package: {ce}')
             raise InvalidRequest('You have uploaded an invalid software update package')
 
         model = await self._get_renewed_model(const.SOFTWARE_UPDATE_ID)

--- a/csm/core/services/hotfix_update.py
+++ b/csm/core/services/hotfix_update.py
@@ -36,7 +36,7 @@ class HotfixApplicationService(UpdateService):
     @Log.trace_method(Log.INFO)
     async def upload_package(self, file_ref, file_name):
         """
-        Upload and validate a hotfix update 
+        Upload and validate a hotfix update
         :param file_ref: An instance of FileRef class that represents a new update package
         :returns: An instance of PackageInformation
         """


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): EOS-18376-Build #589: SMS2: Upload of ISO is failing during update if /tmp/hotfix folder is missing on the node1
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
File upload fails, due to storage directory /tmp/hotfix was missing, 
</pre>
## Solution
<pre>
Added logic to to software update as well as firmware functionality, to check weather storage directories are present or not. If absent then create.
</pre>
## Unit Test Cases
<pre>
Following scenarios tested
1. Upload of package when storage directory is present when csm_agent starts at very first time. --> Happy Path
2. Upload of package when storage directory is present at the time when csm_agent restarts
3. Upload of package when /tmp/fw_update and /tmp/hotfix directories are not present. At this time storage directories are created even if they are not present.
</pre>
Signed-off-by: Udayan Yaragattikar udayan.yaragattikar@seagate.com
