### PR TITLE
EOS-18381: Restricted CLI: CLI Setup command to update configuration

### DIFF
--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -242,6 +242,7 @@ cp "$BASE_DIR/cicd/csm_agent.spec" "$TMPDIR"
     cp -R "$BASE_DIR/templates" "$DIST/csm/"
     cp -R "$BASE_DIR/csm/scripts" "$DIST/csm/"
     cp -R "$BASE_DIR/csm/cli/schema/csm_setup.json" "$DIST/csm/schema/"
+    cp -R "$BASE_DIR/csm/cli/schema/cli_setup.json" "$DIST/csm/schema/"
 
     # Create spec for pyinstaller
     [ "$TEST" == true ] && {

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -206,7 +206,7 @@ else
     # add cortx-py-utils below
     # Need to remove erase of eos-py-utils after re changes
     yum erase -y -q eos-py-utils
-    yum install -y cortx-py-utils 
+    yum install -y cortx-py-utils
     yum install -y python36-cortx-prvsnr
 
     install_py_req requirment.txt
@@ -316,6 +316,8 @@ cp "$BASE_DIR/cicd/cortxcli.spec" "$TMPDIR"
     sed -i -e "s|<PRODUCT>|${PRODUCT}|g" \
         -e "s|<CORTXCLI_PATH>|${TMPDIR}/csm|g" "${PYINSTALLER_FILE}"
     python3 -m PyInstaller --clean -y --distpath "${DIST}/cli" --key "${KEY}" "${PYINSTALLER_FILE}"
+
+    cp -f "$BASE_DIR/csm/cli/conf/cli_setup.py" "$DIST/cli/lib/cli_setup"
 
 ################## Add CORTXCLI_PATH #################################
 

--- a/cicd/cortxcli.spec
+++ b/cicd/cortxcli.spec
@@ -46,6 +46,8 @@ PRODUCT=<PRODUCT>
 [ -d "${CLI_DIR}/lib" ] && {
     ln -sf $CLI_DIR/lib/cortxcli /usr/bin/cortxcli
     ln -sf $CLI_DIR/lib/cortxcli $CLI_DIR/bin/cortxcli
+    ln -sf $CLI_DIR/lib/cli_setup /usr/bin/cli_setup
+    ln -sf $CLI_DIR/lib/cli_setup $CLI_DIR/bin/cli_setup
 }
 
 #TODO: add test for cli
@@ -55,6 +57,7 @@ exit 0
 
 %postun
 rm -f /usr/bin/cortxcli 2> /dev/null;
+rm -f /usr/bin/cli_setup 2> /dev/null;
 rm -rf <CORTXCLI_PATH>/bin/ 2> /dev/null;
 exit 0
 

--- a/cicd/pyinstaller/product_cli.spec
+++ b/cicd/pyinstaller/product_cli.spec
@@ -66,6 +66,22 @@ cortxcli = Analysis([cc_path + '/cli/cortxcli.py'],
              cipher=block_cipher,
              noarchive=False)
 
+cli_setup = Analysis([cc_path + '/cli/conf/cli_setup.py'],
+             pathex=['/usr/lib/python3.6/site-packages/'],
+             binaries=[],
+             datas=[],
+             hiddenimports=product_module_list,
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+
+MERGE( (cortxcli, 'cortxcli', 'cortxcli'),
+       (cli_setup, 'cli_setup', 'cli_setup') )
+
 # cortxcli
 cortxcli_pyz = PYZ(cortxcli.pure, cortxcli.zipped_data,
              cipher=block_cipher)
@@ -81,12 +97,33 @@ cortxcli_exe = EXE(cortxcli_pyz,
           upx=True,
           console=True )
 
+# cli_setup
+cli_setup_pyz = PYZ(cli_setup.pure, cli_setup.zipped_data,
+             cipher=block_cipher)
+
+cli_setup_exe = EXE(cli_setup_pyz,
+          cli_setup.scripts,
+          [],
+          exclude_binaries=True,
+          name='cli_setup',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=True )
+
 coll = COLLECT(
                # cortxcli
                cortxcli_exe,
                cortxcli.binaries,
                cortxcli.zipfiles,
                cortxcli.datas,
+
+               # cli_setup
+               cli_setup_exe,
+               cli_setup.binaries,
+               cli_setup.zipfiles,
+               cli_setup.datas,
 
                strip=False,
                upx=True,

--- a/csm/cli/conf/cli_setup.py
+++ b/csm/cli/conf/cli_setup.py
@@ -65,7 +65,7 @@ class CliSetupCommand:
                                      response=response)
 
 if __name__ == '__main__':
-    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..', '..'))
+    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(os.path.realpath(sys.argv[0]))), '..', '..'))
     from cortx.utils.conf_store.conf_store import Conf
     from csm.common.payload import *
     from csm.cli.command import CommandParser

--- a/csm/cli/conf/cli_setup.py
+++ b/csm/cli/conf/cli_setup.py
@@ -1,0 +1,86 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+import asyncio
+import sys
+import os
+import argparse
+import traceback
+import pathlib
+
+class CliSetupCommand:
+    """
+        Provide cli to setup csm. Create user for csm to allow basic
+        permission like log, bundle path.
+    """
+    def __init__(self, argv):
+        ''' Check csm setup command and initialize '''
+        self._args = argv
+        self._args[0] = 'cli_setup'
+        self._validate()
+        self._loop = asyncio.get_event_loop()
+        Conf.init()
+        Log.init(service_name = "cli_setup", log_path = const.CSM_SETUP_LOG_DIR,
+                level=const.LOG_LEVEL)
+
+    def _validate(self):
+        ''' Validate setup command '''
+        if len(self._args) < 2:
+            raise Exception('Usage: cli_setup -h')
+
+    def _get_command(self):
+        ''' Parse csm setup command '''
+        parser = argparse.ArgumentParser(description='CLI Setup', usage='')
+        subparsers = parser.add_subparsers()
+        # hardcoded permissions
+        cli_setup_permissions_dict = {'update': True}
+        cmd_obj = CommandParser(Json(const.CLI_SETUP_FILE).load(), cli_setup_permissions_dict)
+        cmd_obj.handle_main_parse(subparsers)
+        namespace = parser.parse_args(self._args)
+        sys_module = sys.modules[__name__]
+        for attr in ['command', 'action', 'args']:
+            setattr(sys_module, attr, getattr(namespace, attr))
+            delattr(namespace, attr)
+        return command(action, vars(namespace), args)
+
+    def process(self):
+        ''' Parse args for csm_setup and execute cmd to print output '''
+        self._cmd = self._get_command()
+        obj = CsmDirectClient()
+        response = self._loop.run_until_complete(obj.call(self._cmd))
+        if response:
+            self._cmd.process_response(out=sys.stdout, err=sys.stderr,
+                                     response=response)
+
+if __name__ == '__main__':
+    sys.path.append(os.path.join(os.path.dirname(pathlib.Path(__file__)), '..', '..', '..'))
+    from cortx.utils.conf_store.conf_store import Conf
+    from csm.common.payload import *
+    from csm.cli.command import CommandParser
+    from csm.core.blogic import const
+    from cortx.utils.log import Log
+    from csm.cli.csm_client import CsmDirectClient
+    from csm.cli.conf.post_install import PostInstall
+    from csm.cli.conf.configure import Configure
+    from csm.cli.conf.init import Init
+    from csm.cli.conf.reset import Reset
+    from csm.cli.conf.test import Test
+    try:
+        cli_setup = CliSetupCommand(sys.argv)
+        cli_setup.process()
+        sys.exit(0)
+    except Exception as e:
+        sys.stderr.write('cli_setup command failed: %s\n' %traceback.format_exc())
+        sys.exit(1)

--- a/csm/cli/conf/cli_setup.py
+++ b/csm/cli/conf/cli_setup.py
@@ -26,7 +26,7 @@ class CliSetupCommand:
         permission like log, bundle path.
     """
     def __init__(self, argv):
-        ''' Check csm setup command and initialize '''
+        ''' Check cli setup command and initialize '''
         self._args = argv
         self._args[0] = 'cli_setup'
         self._validate()
@@ -41,7 +41,7 @@ class CliSetupCommand:
             raise Exception('Usage: cli_setup -h')
 
     def _get_command(self):
-        ''' Parse csm setup command '''
+        ''' Parse cli setup command '''
         parser = argparse.ArgumentParser(description='CLI Setup', usage='')
         subparsers = parser.add_subparsers()
         # hardcoded permissions
@@ -56,7 +56,7 @@ class CliSetupCommand:
         return command(action, vars(namespace), args)
 
     def process(self):
-        ''' Parse args for csm_setup and execute cmd to print output '''
+        ''' Parse args for cli_setup and execute cmd to print output '''
         self._cmd = self._get_command()
         obj = CsmDirectClient()
         response = self._loop.run_until_complete(obj.call(self._cmd))

--- a/csm/cli/conf/configure.py
+++ b/csm/cli/conf/configure.py
@@ -1,0 +1,43 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+from cortx.utils.log import Log
+from csm.conf.setup import Setup
+from csm.core.blogic import const
+from csm.core.providers.providers import Response
+from csm.common.errors import CSM_OPERATION_SUCESSFUL
+
+
+class Configure(Setup):
+    """
+    Configure CORTX CLI
+
+    Config is used to move/update configuration files (one time configuration).
+    """
+
+    def __init__(self):
+        super(Configure, self).__init__()
+
+    async def execute(self, command):
+        """
+        Execute CORTX CLI setup Config Command
+
+        :param command: Command Object For CLI. :type: Command
+        :return: 0 on success, RC != 0 otherwise.
+        """
+
+        Log.info("Executing Config for CORTX CLI")
+        return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)

--- a/csm/cli/conf/configure.py
+++ b/csm/cli/conf/configure.py
@@ -13,9 +13,12 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-
+import os
+import traceback
+from cortx.utils.conf_store.conf_store import Conf
+from cortx.utils.kv_store.error import KvError
 from cortx.utils.log import Log
-from csm.conf.setup import Setup
+from csm.conf.setup import Setup, CsmSetupError
 from csm.core.blogic import const
 from csm.core.providers.providers import Response
 from csm.common.errors import CSM_OPERATION_SUCESSFUL
@@ -40,4 +43,39 @@ class Configure(Setup):
         """
 
         Log.info("Executing Config for CORTX CLI")
+        try:
+            Conf.load(const.CONSUMER_INDEX, command.options.get(const.CONFIG_URL))
+            Conf.load(const.CORTXCLI_GLOBAL_INDEX, const.CORTXCLI_CONF_FILE_URL)
+            self._set_deployment_mode()
+            self.cli_create(command)
+        except KvError as e:
+            err_msg = f"Failed to load the configuration: {e}"
+            Log.error(err_msg)
+            raise CsmSetupError(err_msg)
+        except Exception as e:
+            err_msg = (f"cli_setup config command failed. Error: "
+                       f"{e} - {str(traceback.format_exc())}")
+            Log.error(err_msg)
+            raise CsmSetupError(err_msg)
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
+
+    def cli_create(self, command):
+        """
+        Create the CortxCli configuration file on the required location.
+        """
+
+        os.makedirs(const.CORTXCLI_PATH, exist_ok=True)
+        os.makedirs(const.CORTXCLI_CONF_PATH, exist_ok=True)
+        Setup._run_cmd(
+            f"setfacl -R -m u:{self._user}:rwx {const.CORTXCLI_PATH}")
+        Setup._run_cmd(
+            f"setfacl -R -m u:{self._user}:rwx {const.CORTXCLI_CONF_PATH}")
+        Conf.set(const.CORTXCLI_GLOBAL_INDEX,
+                 f"{const.CORTXCLI_SECTION}>{const.CSM_AGENT_HOST_PARAM_NAME}" ,
+                 command.options.get(const.ADDRESS_PARAM, "127.0.0.1"))
+        if self._is_env_dev:
+            Conf.set(const.CORTXCLI_GLOBAL_INDEX,
+                     f"{const.DEPLOYMENT}>{const.MODE}", const.DEV)
+        Conf.save(const.CORTXCLI_GLOBAL_INDEX)
+        Setup._run_cmd(
+            f"cp -rn {const.CORTXCLI_SOURCE_CONF_PATH} {const.ETC_PATH}")

--- a/csm/cli/conf/init.py
+++ b/csm/cli/conf/init.py
@@ -1,0 +1,40 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+from cortx.utils.log import Log
+from csm.conf.setup import Setup
+from csm.core.blogic import const
+from csm.core.providers.providers import Response
+from csm.common.errors import CSM_OPERATION_SUCESSFUL
+
+
+class Init(Setup):
+    """
+    Init CORTX CLI
+    """
+
+    def __init__(self):
+        super(Init, self).__init__()
+
+    async def execute(self, command):
+        """
+        Execute CORTX CLI setup Init Command
+        :param command: Command Object For CLI. :type: Command
+        :return: 0 on success, RC != 0 otherwise.
+        """
+
+        Log.info("Executing Init for CORTX CLI")
+        return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)

--- a/csm/cli/conf/post_install.py
+++ b/csm/cli/conf/post_install.py
@@ -1,0 +1,44 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+from cortx.utils.log import Log
+from csm.conf.setup import Setup
+from csm.core.blogic import const
+from csm.core.providers.providers import Response
+from csm.common.errors import CSM_OPERATION_SUCESSFUL
+
+
+class PostInstall(Setup):
+    """
+    Post-install CORTX CLI
+
+    Post install is used after just all rpms are install but
+    no service are started
+    """
+
+    def __init__(self):
+        super(PostInstall, self).__init__()
+
+    async def execute(self, command):
+        """
+        Execute CORTX CLI setup Post-install Command
+
+        :param command: Command Object For CLI. :type: Command
+        :return: 0 on success, RC != 0 otherwise.
+        """
+
+        Log.info("Executing Post-install for CORTX CLI")
+        return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)

--- a/csm/cli/conf/reset.py
+++ b/csm/cli/conf/reset.py
@@ -1,0 +1,38 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+from cortx.utils.log import Log
+from csm.conf.setup import Setup
+from csm.core.providers.providers import Response
+from csm.core.blogic import const
+from csm.common.errors import CSM_OPERATION_SUCESSFUL
+
+
+class Reset(Setup):
+    """
+    Reset CORTX CLI configuration
+    """
+
+    def __init__(self):
+        super(Reset, self).__init__()
+
+    async def execute(self, command):
+        """
+        :param command:
+        :return:
+        """
+        Log.info("Executing Reset for CORTX CLI")
+        return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)

--- a/csm/cli/conf/test.py
+++ b/csm/cli/conf/test.py
@@ -1,0 +1,43 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+from cortx.utils.log import Log
+from csm.core.blogic import const
+from csm.core.providers.providers import Response
+from csm.conf.setup import Setup
+from csm.common.errors import CSM_OPERATION_SUCESSFUL
+
+
+class Test(Setup):
+    """
+    Test CORTX CLI
+
+    Run tests to ensure CORTX CLI is set up properly.
+    """
+
+    def __init__(self):
+        super(Test, self).__init__()
+
+    async def execute(self, command):
+        """
+        Execute CORTX CLI setup Test Command
+
+        :param command: Command Object For CLI. :type: Command
+        :return: 0 on success, RC != 0 otherwise.
+        """
+
+        Log.info("Executing Test for CORTX CLI")
+        return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)

--- a/csm/cli/schema/cli_setup.json
+++ b/csm/cli/schema/cli_setup.json
@@ -114,33 +114,6 @@
       }
     },
     {
-      "name": "refresh_config",
-      "description": "Refresh Context for CORTX CLI.",
-      "need_confirmation": false,
-      "permissions_tag": "update",
-      "args": [
-        {
-          "flag": "--config",
-          "dest": "config_url",
-          "type": "str",
-          "help": "Config Store URL e.g <type>://<path>."
-        },
-        {
-          "flag": "args",
-          "default": [],
-          "suppress_help": true,
-          "nargs": "?"
-        }
-      ],
-      "comm": {
-        "type": "direct",
-        "target": "csm.cli.conf.refresh_config",
-        "method": "execute",
-        "class": "RefreshConfig",
-        "is_static": false
-      }
-    },
-    {
       "name": "test",
       "description": "Run Self Test Command For CORTX CLI.",
       "need_confirmation": false,

--- a/csm/cli/schema/cli_setup.json
+++ b/csm/cli/schema/cli_setup.json
@@ -1,0 +1,182 @@
+{
+  "name": "cli_setup",
+  "description": "CLI Setup Command",
+  "sub_commands": [
+    {
+      "name": "init",
+      "description": "Initialize CORTX CLI",
+      "need_confirmation": false,
+      "permissions_tag": "update",
+      "args": [
+        {
+          "flag": "--config",
+          "dest": "config_url",
+          "type": "str",
+          "help": "Config Store URL e.g <type>://<path>."
+        },
+        {
+          "flag": "args",
+          "default": [],
+          "suppress_help": true,
+          "nargs": "?"
+        }
+      ],
+      "comm": {
+        "type": "direct",
+        "target": "csm.cli.conf.init",
+        "method": "execute",
+        "class": "Init",
+        "is_static": false
+      }
+    },
+    {
+      "name": "post_install",
+      "description": "Perform post_install for CORTX CLI",
+      "need_confirmation": false,
+      "permissions_tag": "update",
+      "args": [
+        {
+          "flag": "--config",
+          "dest": "config_url",
+          "type": "str",
+          "required": true,
+          "help": "Config Store URL e.g <type>://<path>."
+        },
+        {
+          "flag": "args",
+          "default": [],
+          "suppress_help": true,
+          "nargs": "?"
+        }
+      ],
+      "comm": {
+        "type": "direct",
+        "target": "csm.cli.conf.post_install",
+        "method": "execute",
+        "class": "PostInstall",
+        "is_static": false
+      }
+    },
+    {
+      "name": "config",
+      "description": "Config CORTX CLI",
+      "need_confirmation": false,
+      "permissions_tag": "update",
+      "args": [
+        {
+          "flag": "--config",
+          "dest": "config_url",
+          "type": "str",
+          "required": true,
+          "help": "Config Store URL e.g <type>://<path>."
+        },
+        {
+          "flag": "args",
+          "default": [],
+          "suppress_help": true,
+          "nargs": "?"
+        }
+      ],
+      "comm": {
+        "type": "direct",
+        "target": "csm.cli.conf.configure",
+        "method": "execute",
+        "class": "Configure",
+        "is_static": false
+      }
+    },
+    {
+      "name": "reset",
+      "description": "Perform reset for CORTX CLI",
+      "need_confirmation": false,
+      "permissions_tag": "update",
+      "args": [
+        {
+          "flag": "args",
+          "default": [],
+          "suppress_help": true,
+          "nargs": "?"
+        }
+      ],
+      "comm": {
+        "type": "direct",
+        "target": "csm.cli.conf.reset",
+        "method": "execute",
+        "class": "Reset",
+        "is_static": false
+      }
+    },
+    {
+      "name": "refresh_config",
+      "description": "Refresh Context for CORTX CLI.",
+      "need_confirmation": false,
+      "permissions_tag": "update",
+      "args": [
+        {
+          "flag": "--config",
+          "dest": "config_url",
+          "type": "str",
+          "help": "Config Store URL e.g <type>://<path>."
+        },
+        {
+          "flag": "args",
+          "default": [],
+          "suppress_help": true,
+          "nargs": "?"
+        }
+      ],
+      "comm": {
+        "type": "direct",
+        "target": "csm.cli.conf.refresh_config",
+        "method": "execute",
+        "class": "RefreshConfig",
+        "is_static": false
+      }
+    },
+    {
+      "name": "test",
+      "description": "Run Self Test Command For CORTX CLI.",
+      "need_confirmation": false,
+      "permissions_tag": "update",
+      "args": [
+        {
+          "flag": "-t",
+          "default": "",
+          "type": "str",
+          "help": "Plan File Name that needs to be Executed."
+        },
+        {
+          "flag": "-f",
+          "default": "",
+          "type": "str",
+          "help": "Path of args.yaml."
+        },
+       {
+          "flag": "-l",
+          "default": "",
+          "type": "str",
+          "help": "Path for log file."
+        },
+        {
+          "flag": "-o",
+          "default": "",
+          "type": "str",
+          "help": "Print final result in file return fail if any one of test failed."
+        },
+        {
+          "flag": "args",
+          "default": [],
+          "suppress_help": true,
+          "nargs": "?"
+        }
+      ],
+      "comm": {
+        "type": "direct",
+        "target": "csm.cli.conf.test",
+        "method": "execute",
+        "class": "Test",
+        "is_static": false
+      }
+    }
+  ]
+}

--- a/csm/cli/schema/cli_setup.json
+++ b/csm/cli/schema/cli_setup.json
@@ -71,6 +71,13 @@
           "help": "Config Store URL e.g <type>://<path>."
         },
         {
+          "flag": "--csm-address",
+          "dest": "Address",
+          "type": "str",
+          "default": "127.0.0.1",
+          "help": "CSM URL"
+        },
+        {
           "flag": "args",
           "default": [],
           "suppress_help": true,

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -297,6 +297,7 @@ FAULT_HEALTH = 'Fault'
 ALERT_MAPPING_TABLE = '{}/schema/alert_mapping_table.json'.format(CSM_PATH)
 HEALTH_MAPPING_TABLE = '{}/schema/csm_health_schema.json'.format(CSM_PATH)
 CSM_SETUP_FILE = '{}/schema/csm_setup.json'.format(CSM_PATH)
+CLI_SETUP_FILE = '{}/schema/cli_setup.json'.format(CSM_PATH)
 
 # Support Bundle
 SSH_USER_NAME = 'root'


### PR DESCRIPTION
# Backend

## Problem Statement
Story Ref (if any): [EOS-18381](https://jts.seagate.com/browse/EOS-18381)
## Unit testing on RPM done
Yes
## Problem Description
The cli_setup utility is required to update the CORTX CLI configuration according to the Mini-provisioner API specification.
## Solution
Implemented the cli_setup utility based on the csm_setup framework.
## Unit Test Cases
- cli_setup config --config \<URL\>

Signed-off-by: Alexander Voronov <alexander.voronov@seagate.com>
