### PR TITLE
S3 Audit log fix for msg field

### DIFF
--- a/csm/core/blogic/models/audit_log.py
+++ b/csm/core/blogic/models/audit_log.py
@@ -49,4 +49,5 @@ class S3AuditLogModel(CsmModel):
     turn_around_time = StringType()
     user_agent = StringType()
     version_id = StringType()
+    msg = StringType(min_length=0)
 

--- a/csm/core/services/audit_log.py
+++ b/csm/core/services/audit_log.py
@@ -48,7 +48,7 @@ COMPONENT_MODEL_MAPPING = { "csm":
       "{remote_ip} {requester} {request_id} {operation} {key} {request_uri}"
       "{http_status} {error_code} {bytes_sent} {object_size} {total_time}"
       "{turn_around_time} {referrer} {user_agent} {version_id} {host_id}"
-      "{signature_version} {cipher_suite} {authentication_type} {host_header}")
+      "{signature_version} {cipher_suite} {authentication_type} {host_header} {msg}")
                             }
                           }
 COMPONENT_NOT_FOUND = "no_audit_log_for_component"

--- a/csm/core/services/audit_log.py
+++ b/csm/core/services/audit_log.py
@@ -44,10 +44,10 @@ COMPONENT_MODEL_MAPPING = { "csm":
                             "s3":
                             { "model" : S3AuditLogModel,
                               "field" : S3AuditLogModel.timestamp,
-                              "format" : ("{bucket_owner} {bucket} {time}"
-      "{remote_ip} {requester} {request_id} {operation} {key} {request_uri}"
-      "{http_status} {error_code} {bytes_sent} {object_size} {total_time}"
-      "{turn_around_time} {referrer} {user_agent} {version_id} {host_id}"
+                              "format" : ("{bucket_owner} {bucket} {time} "
+      "{remote_ip} {requester} {request_id} {operation} {key} {request_uri} "
+      "{http_status} {error_code} {bytes_sent} {object_size} {total_time} "
+      "{turn_around_time} {referrer} {user_agent} {version_id} {host_id} "
       "{signature_version} {cipher_suite} {authentication_type} {host_header} {msg}")
                             }
                           }


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
S3 audit logs are throwing exception.
Story Ref (if any): https://jts.seagate.com/browse/EOS-18555 
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
S3 audit logs were not shown in case of entries with msg field. 
</pre>
## Solution
<pre>
"msg" field is added in S3AuditLogModel in CSM.
</pre>
## Unit Test Cases
<pre>
Tested on smc69-m10.colo.seagate.com and smc70-m10.colo.seagate.com for the timestamp when there are entries with msg field
![MicrosoftTeams-image (14)](https://user-images.githubusercontent.com/64407225/110635628-4f173100-81d1-11eb-98ed-019e77a05c76.png)
![MicrosoftTeams-image (15)](https://user-images.githubusercontent.com/64407225/110637112-11b3a300-81d3-11eb-982f-1531fecff2ec.png)


</pre>
Signed-off-by: 
