### PR TITLE
EOS-18569: BE: Use boto3 package instead of boto package

### DIFF
--- a/cicd/pyinstaller/requirment.txt
+++ b/cicd/pyinstaller/requirment.txt
@@ -9,7 +9,6 @@ prettytable==0.7.2
 pika==1.1.0
 idna==2.8
 jsonschema==3.0.2
-boto==2.49.0
 boto3==1.10.27
 marshmallow==3.2.1
 schematics==2.1.0

--- a/cicd/pyinstaller/requirment.txt
+++ b/cicd/pyinstaller/requirment.txt
@@ -4,6 +4,7 @@ toml==0.10.0
 configparser==4.0.2
 argparse==1.4.0
 dict2xml==1.6.1
+xmltodict==0.12.0
 prettytable==0.7.2
 pika==1.1.0
 idna==2.8

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -331,21 +331,43 @@ S3_MAX_RETRIES_NUM = 'S3>max_retries_num'
 S3_LDAP_LOGIN = 'S3>ldap_login'
 S3_LDAP_PASSWORD = 'S3>ldap_password'
 
+S3_CREATE_ACCOUNT_RESP_ACCOUNT_PATH = (
+    'CreateAccountResponse', 'CreateAccountResult', 'Account')
+S3_CREATE_ACCOUNT_LOGIN_PROFILE_RESP_PROFILE_PATH = (
+    'CreateAccountLoginProfileResponse', 'CreateAccountLoginProfileResult', 'LoginProfile')
+S3_LIST_ACCOUNTS_RESP_ACCOUNTS_PATH = (
+     'ListAccountsResponse', 'ListAccountsResult', 'Accounts')
+S3_LIST_ACCOUNTS_RESP_ISTRUNCATED_PATH = (
+    'ListAccountsResponse', 'ListAccountsResult', 'IsTruncated')
+S3_LIST_ACCOUNTS_RESP_MARKER_PATH = (
+    'ListAccountsResponse', 'ListAccountsResult', 'Marker')
+S3_RESET_ACCOUNT_ACCESS_KEY_RESP_ACCOUNT_PATH = (
+    'ResetAccountAccessKeyResponse', 'ResetAccountAccessKeyResult', 'Account')
+S3_CREATE_USER_RESP_USER_PATH = (
+    'CreateUserResponse', 'CreateUserResult', 'User')
+S3_LIST_USERS_RESP_ISTRUNCATED_PATH = (
+    'ListUsersResponse', 'ListUsersResult', 'IsTruncated')
+S3_LIST_USERS_RESP_MARKER_PATH = (
+    'ListUsersResponse', 'ListUsersResult', 'Marker')
+S3_CREATE_ACCESS_KEY_RESP_KEY_PATH = (
+    'CreateAccessKeyResponse', 'CreateAccessKeyResult', 'AccessKey')
+S3_GET_ACCESS_KEY_LAST_RESP_KEY_PATH = (
+    'GetAccessKeyLastUsedResponse', 'GetAccessKeyLastUsedResult', 'AccessKeyLastUsed')
+S3_LIST_ACCESS_KEYS_RESP_KEYS_PATH = (
+    'ListAccessKeysResponse', 'ListAccessKeysResult', 'AccessKeyMetadata')
+S3_LIST_ACCESS_KEYS_RESP_ISTRUNCATED_PATH = (
+    'ListAccessKeysResponse', 'ListAccessKeysResult', 'IsTruncated')
+S3_LIST_ACCESS_KEYS_RESP_MARKER_PATH = (
+    'ListAccessKeysResponse', 'ListAccessKeysResult', 'Marker')
+S3_GET_TMP_CREDS_RESP_CREDS_PATH = (
+    'GetTempAuthCredentialsResponse', 'GetTempAuthCredentialsResult', 'AccessKey')
+
+
 S3_IAM_CMD_CREATE_ACCESS_KEY = 'CreateAccessKey'
-S3_IAM_CMD_CREATE_ACCESS_KEY_RESP = 'CreateAccessKeyResponse'
-S3_IAM_CMD_CREATE_ACCESS_KEY_RESULT = 'CreateAccessKeyResult'
 S3_IAM_CMD_UPDATE_ACCESS_KEY = 'UpdateAccessKey'
-S3_PARAM_ACCESS_KEY = 'AccessKey'
 S3_ACCESS_KEY_STATUSES = ['Active', 'Inactive']
 S3_IAM_CMD_GET_ACCESS_KEY_LAST_USED = 'GetAccessKeyLastUsed'  # not supported by the S3 server yet
-S3_IAM_CMD_GET_ACCESS_KEY_LAST_USED_RESP = 'GetAccessKeyLastUsedResponse'
-S3_IAM_CMD_GET_ACCESS_KEY_LAST_USED_RESULT = 'GetAccessKeyLastUsedResult'
-S3_PARAM_ACCESS_KEY_LAST_USED = 'AccessKeyLastUsed'
 S3_IAM_CMD_LIST_ACCESS_KEYS = 'ListAccessKeys'
-S3_IAM_CMD_LIST_ACCESS_KEYS_RESP = 'ListAccessKeysResponse'
-S3_IAM_CMD_LIST_ACCESS_KEYS_RESULT = 'ListAccessKeysResult'
-S3_PARAM_ACCESS_KEY_METADATA = 'AccessKeyMetadata'
-S3_PARAM_IS_TRUNCATED = 'IsTruncated'
 S3_PARAM_USER_NAME = 'UserName'
 S3_PARAM_MARKER = 'Marker'
 S3_PARAM_MAX_ITEMS = 'MaxItems'

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -351,6 +351,17 @@ S3_PARAM_MARKER = 'Marker'
 S3_PARAM_MAX_ITEMS = 'MaxItems'
 S3_IAM_CMD_DELETE_ACCESS_KEY = 'DeleteAccessKey'
 
+# S3/Boto3
+S3_DEFAULT_REGION = 'us-west2'
+S3_RESOURCE_NAME_IAM = 'iam'
+S3_RESOURCE_NAME_S3 = 's3'
+S3_DEFAULT_RETRIES_MODE = 'standard'
+S3_DEFAULT_REQUEST_HEADERS = {
+    'content-type': 'application/x-www-form-urlencoded',
+    'accept': 'text/plain',
+}
+S3_RESP_LIST_ITEM = 'member'
+
 # UDS/USL
 UDS_SERVER_DEFAULT_BASE_URL = 'http://localhost:5000'
 UDS_CERTIFICATES_PATH = '/var/csm/tls'

--- a/csm/core/services/s3/buckets.py
+++ b/csm/core/services/s3/buckets.py
@@ -16,7 +16,6 @@
 from typing import Dict
 
 from botocore.exceptions import ClientError
-from boto.s3.bucket import Bucket
 
 from cortx.utils.log import Log
 

--- a/csm/core/services/s3/buckets.py
+++ b/csm/core/services/s3/buckets.py
@@ -45,8 +45,8 @@ class S3BucketService(S3BaseService):
         :return:
         """
         # TODO: it should be a common method for all services
-        return self._s3plugin.get_s3_client(access_key=s3_session.access_key,
-                                            secret_key=s3_session.secret_key,
+        return self._s3plugin.get_s3_client(access_key_id=s3_session.access_key,
+                                            secret_access_key=s3_session.secret_key,
                                             connection_config=self._s3_connection_config,
                                             session_token=s3_session.session_token)
 

--- a/csm/core/services/usl.py
+++ b/csm/core/services/usl.py
@@ -18,7 +18,6 @@ import time
 
 from aiohttp import ClientSession, TCPConnector
 from aiohttp import ClientError as HttpClientError
-from boto.s3.bucket import Bucket
 from random import SystemRandom
 from marshmallow import ValidationError
 from marshmallow.validate import URL
@@ -135,7 +134,7 @@ class UslService(ApplicationService):
         """Generates the CORTX volume (bucket) UUID from CORTX device UUID and bucket name."""
         return uuid5(self._device_uuid, bucket_name)
 
-    async def _format_bucket_as_volume(self, bucket: Bucket) -> Volume:
+    async def _format_bucket_as_volume(self, bucket) -> Volume:
         bucket_name = bucket.name
         volume_name = await self._get_volume_name(bucket_name)
         device_uuid = self._device_uuid

--- a/csm/plugins/cortx/s3.py
+++ b/csm/plugins/cortx/s3.py
@@ -125,7 +125,6 @@ class BaseClient:
                 body = await resp.text()
                 parsed_body = xmltodict.parse(
                     body, force_list=const.S3_RESP_LIST_ITEM) if body else {}
-                print(f'{action} - {status}\n{parsed_body}')
                 Log.debug('%s responded with %s status', self._host, status)
                 return (status, parsed_body)
 

--- a/csm/plugins/cortx/s3.py
+++ b/csm/plugins/cortx/s3.py
@@ -226,7 +226,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('CreateAccount', params, '/', 'POST')
         Log.debug(f"Create account profile status: {code}")
-        if code != 201:
+        if code != HTTPStatus.CREATED:
             return self._create_error(code, body)
         else:
             account = body['CreateAccountResponse']['CreateAccountResult']['Account']
@@ -256,7 +256,7 @@ class IamClient(BaseClient):
         (code, body) = await self._arbitrary_request(
             'CreateAccountLoginProfile', params, '/', 'POST')
         Log.debug(f"Create login profile status: {code}")
-        if code != 201:
+        if code != HTTPStatus.CREATED:
             return self._create_error(code, body)
         else:
             profile = body['CreateAccountLoginProfileResponse']['CreateAccountLoginProfileResult']
@@ -284,7 +284,7 @@ class IamClient(BaseClient):
         (code, body) = await self._arbitrary_request(
             'UpdateAccountLoginProfile', params, '/', 'POST')
         Log.debug(f"Update account profile status: {code}")
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             return True
@@ -304,7 +304,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('GetAccountLoginProfile', params, '/', 'POST')
         Log.debug(f"List account profile status: {code}")
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             return True
@@ -339,7 +339,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('ListAccounts', params, '/', 'POST')
         Log.debug(f"List account status: {code}")
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             users = self._extract_list(
@@ -373,7 +373,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('ResetAccountAccessKey', params, '/', 'POST')
         Log.debug(f"Reset account access key status code: {code}")
-        if code != 201:
+        if code != HTTPStatus.CREATED:
             return self._create_error(code, body)
         else:
             result = body['ResetAccountAccessKeyResponse']['ResetAccountAccessKeyResult']
@@ -402,7 +402,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('DeleteAccount', params, '/', 'POST')
         Log.debug(f"Delete account status code: {code}")
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             return True
@@ -421,7 +421,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('CreateUser', params, '/', 'POST')
         Log.debug(f"Create iam user status code: {code}")
-        if code != 201:
+        if code != HTTPStatus.CREATED:
             return self._create_error(code, body)
         else:
             user = body['CreateUserResponse']['CreateUserResult']['User']
@@ -440,7 +440,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('CreateLoginProfile', params, '/', 'POST')
         Log.debug(f"Create user profile status code: {code}")
-        if code != 201:
+        if code != HTTPStatus.CREATED:
             return self._create_error(code, body)
         else:
             return None
@@ -465,7 +465,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('UpdateLoginProfile', params, '/', 'POST')
         Log.debug(f"Update user profile status: {code}")
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             return True
@@ -490,7 +490,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('ListUsers', params, '/', 'POST')
         Log.debug(f"List iam User status code: {code}")
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             users = self._extract_list(['ListUsersResponse', 'ListUsersResult', 'Users'], body)
@@ -521,7 +521,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('DeleteUser', params, '/', 'POST')
         Log.debug(f"Delete iam User status code: {code}")
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             return True
@@ -541,7 +541,7 @@ class IamClient(BaseClient):
         }
 
         (code, body) = await self._arbitrary_request('GetUser', params, '/', 'POST')
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             return None
@@ -567,7 +567,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request('UpdateUser', params, '/', 'POST')
         Log.debug(f"Update iam User status code: {code}")
-        if code != 200:
+        if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
             # TODO: our IAM server does not return the updated user information
@@ -953,7 +953,7 @@ class S3Plugin:
 
         (code, body) = await iamcli._arbitrary_request(
             'GetTempAuthCredentials', params, '/', 'POST')
-        if code != 201:
+        if code != HTTPStatus.CREATED:
             return iamcli._create_error(code, body)
         else:
             creds = body['GetTempAuthCredentialsResponse']['GetTempAuthCredentialsResult']

--- a/csm/plugins/cortx/s3.py
+++ b/csm/plugins/cortx/s3.py
@@ -26,10 +26,7 @@ from concurrent.futures import ThreadPoolExecutor
 import ssl
 from typing import Any, Callable, Dict, List, Tuple, Optional, Union
 from http import HTTPStatus
-# FIXME: Temporarily disable xmltodict until RE dependency is handled and installed.
-# Replace the S3RespParser with xmltodict once xmltodict>=0.12.0 is available.
-# import xmltodict
-import xml.sax
+import xmltodict
 from cortx.utils.log import Log
 import json
 from csm.common.errors import CsmInternalError, CsmTypeError
@@ -39,155 +36,6 @@ from csm.core.data.models.s3 import (S3ConnectionConfig, IamAccount, ExtendedIam
                                      IamAccountListResponse, IamTempCredentials, IamUserCredentials,
                                      IamAccessKeyMetadata, IamAccessKeysListResponse,
                                      IamAccessKeyLastUsed, IamErrors, IamError)
-
-
-Element = namedtuple('Element', 'type val')
-TYPE_KEY = 'key'
-TYPE_VAL = 'value'
-
-
-class S3RespParser(xml.sax.ContentHandler):
-    """
-    XML SAX Content handler for parsing S3 server responses.
-    """
-
-    def __init__(self, force_list: List[str] = []) -> None:
-        """
-        Initialize S3RespParser.
-
-        :param for_list: list of keys that values should be treated as lists.
-        """
-        self._stack = []
-        self._force_list = force_list
-
-    def startElement(self, name: str, attrs: List[str]) -> None:
-        """
-        Implement startElement for xml.sax.ContentHandler.
-
-        :param name: name of the element (e.g. for <Response> it's 'Response').
-        :param attrs: XML attributes of the element (e.g. <Response attr1='attr1)).
-                      attrs are ignored by the current implementation (S3 server doesn't use them).
-        """
-
-        element = Element(TYPE_KEY, name)
-        self._stack.append(element)
-
-    def endElement(self, name: str) -> None:
-        """
-        Implement endElement for xml.sax.ContentHandler.
-
-        :param name: name of the element (e.g. for </Response> it's 'Response').
-        """
-
-        acc = None
-        # Logic: extract values from stack and merge them until the key appears
-        # If key's name matches the name from parameters assign the merged value
-        # to the key and push the resulting value to the stack
-        while len(self._stack):
-            element = self._stack.pop()
-            if element.type == TYPE_KEY:
-                if element.val != name:
-                    raise CsmTypeError(f'Malformed XML: expected </{name}>, got </{element.val}>')
-                if name in self._force_list:
-                    acc = [acc]
-                acc_elem = Element(TYPE_VAL, {name: acc})
-                self._stack.append(acc_elem)
-                break
-            else:
-                acc = S3RespParser.merge(acc, element.val)
-        if not len(self._stack):
-            raise CsmTypeError(f'Malformed XML: unexpected </{name}>')
-
-    def characters(self, content: str) -> None:
-        """
-        Implements characters for xml.sax.ContentHandler.
-
-        :param content: text appeared during parsing an XML document.
-        """
-
-        content = content.strip()
-        if not content:
-            return
-        element = Element(TYPE_VAL, content)
-        self._stack.append(element)
-
-    @staticmethod
-    def merge_str(acc: str, elem: str) -> str:
-        """
-        Merge the string from the stack with the accumulator string.
-
-        :param acc: the accumulator string.
-        :param elem: the string from the stack.
-        :returns: concatenated string.
-        """
-
-        if not isinstance(elem, str):
-            msg = f'Unexpected element to merge: {elem} of type {type(elem)} (expected str)'
-            raise CsmTypeError(msg)
-        return ' '.join([elem, acc])
-
-    @staticmethod
-    def merge_dict(acc: Dict[str, Any], elem: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Merges the dict value from the stack with the accumulator dict.
-
-        :param acc: the accumulator dict.
-        :param elem: the dict from the stack.
-        :returns: the merged dict.
-        """
-
-        if not isinstance(elem, dict) or len(elem.keys()) != 1:
-            msg = f'Unexpected element to merge: {elem} of type {type(elem)}'\
-                f' (expected dict with single key)'
-            raise CsmTypeError(msg)
-        key = list(elem.keys())[0]
-        val = elem[key]
-        # merge dicts with different keys
-        if key not in acc.keys():
-            acc.update(elem)
-            return acc
-        # merge acc[key] and elem[key] into { 'key': [acc[key], elem[key]]}
-        if isinstance(acc[key], list):
-            if isinstance(val, list):
-                acc[key] = acc[key] + val
-            else:
-                acc[key].append(val)
-        else:
-            acc[key] = [acc[key], val]
-        return acc
-
-    @staticmethod
-    def merge(
-        acc: Optional[Union[str, Dict[str, Any]]], elem: Union[str, Dict[str, Any]]
-    ) -> Union[str, Dict[str, Any]]:
-        """
-        Merge the element from the stack with the accumulator element.
-
-        :param acc: the accumulator element.
-        :param elem: the element from the stack.
-        :returns: merged object (str or dict).
-        """
-
-        # merge None
-        if acc is None:
-            return elem
-        # merge strings
-        if isinstance(acc, str):
-            return S3RespParser.merge_str(acc, elem)
-        # merge dicts
-        if isinstance(acc, dict):
-            return S3RespParser.merge_dict(acc, elem)
-        msg = f'Parsing error. Element {elem} of type {type(elem)} is not None, str or dict'
-        raise CsmTypeError(msg)
-
-    def root(self) -> Dict[str, Any]:
-        """
-        Get parser's stack root element.
-
-        Used to obtain the parsed result.
-        """
-
-        return self._stack[0].val
 
 
 class BaseClient:
@@ -276,13 +124,9 @@ class BaseClient:
                                             timeout=const.TIMEOUT) as resp:
                 status = resp.status
                 body = await resp.text()
-                # FIXME: Temporarily disable xmltodict until RE dependency is handled and installed.
-                # Replace the S3RespParser with xmltodict once xmltodict>=0.12.0 is available.
-                # parsed_body = xmltodict.parse(
-                #     body, force_list=const.S3_RESP_LIST_ITEM) if body else {}
-                parser = S3RespParser(force_list=[const.S3_RESP_LIST_ITEM])
-                xml.sax.parseString(body, parser)
-                parsed_body = parser.root()
+
+                parsed_body = xmltodict.parse(
+                    body, force_list=const.S3_RESP_LIST_ITEM) if body else {}
                 Log.debug('%s responded with %s status', self._host, status)
                 return (status, parsed_body)
 

--- a/test/s3/test_s3.py
+++ b/test/s3/test_s3.py
@@ -179,7 +179,7 @@ def test_delete_account(args):
     account = args['s3_account']
 
     iam_conf = S3ConnectionConfig()
-    iam_conf.host = "sati10b-m08.mero.colo.seagate.com"
+    iam_conf.host = args['S3']['host']
     iam_conf.port = 9080
 
     delete_client = s3_plugin.get_iam_client(account.access_key_id, account.secret_key_id, iam_conf)
@@ -254,5 +254,5 @@ test_list = [test_create_account,
              test_create_iam_user, test_create_list_delete_iam_user_credentials,
              test_delete_iam_user,
              test_create_list_delete_bucket,
-             test_delete_account,
-             test_disallow_list_lyve_pilot_bucket, test_disallow_delete_lyve_pilot_bucket]
+             test_disallow_list_lyve_pilot_bucket, test_disallow_delete_lyve_pilot_bucket,
+             test_delete_account]

--- a/test/test_data/args.yaml
+++ b/test/test_data/args.yaml
@@ -17,6 +17,6 @@
 # CSM Test Parameters (YAML Format)
 ########################################
 S3:
-  host: "sati10b-m08.mero.colo.seagate.com"
+  host: "localhost"
   login: "sgiamadmin"
   password: "ldapadmin"


### PR DESCRIPTION
# Backend

## Problem Statement
Story Ref (if any): [EOS-18569](https://jts.seagate.com/browse/EOS-18569)
## Unit testing on RPM done
Yes
## Problem Description
At the beginning of CORTX CSM team chose boto2 for handling CORTX-specific requests to IAM server (e.g. CreateAccount, CreateAccountLoginProfile, etc.). Per architects' query the dependency on boto2 should be removed.
## Solution
- Implement a method for sending arbitrary AWS-signed requests leveraging boto3's SignV4.
- Implement a new parser for IAM server's responses (the old one leveraged boto.XMLParser).
## Unit Test Cases
- csm/test/plans/s3.pln:test_s3
