### PR TITLE
EOS-18886: Execute UDS config only in supported devices 

### DIFF
--- a/csm/conf/uds.py
+++ b/csm/conf/uds.py
@@ -206,7 +206,10 @@ backend uds-backend
 
     @classmethod
     def remove_uds_config(cls):
-        rmtree(cls.UDS_CONFIG_DIR)
+        try:
+            rmtree(cls.UDS_CONFIG_DIR)
+        except FileNotFoundError:
+            pass
 
     @classmethod
     def apply(cls, uds_public_ip):


### PR DESCRIPTION
# Backend

## Problem Statement

[EOS-18886: Create & Build OVA 1.0.4](https://jts.seagate.com/browse/EOS-18886)

See ticket for details.

## Unit testing on RPM done

Yes.

## Problem Description

See tickets for details.

## Solution

- Add following checks before running UDS config step:
  * ~`csm_setup` is running on VM;~ _(note: removed after review)_
  * `lyve_pilot` is not on the list of unsupported features for the machine storage type.
- Do not raise an exception when attempting to remove UDS config directory if it does not exist

## Test Cases

N/A
