### PR TITLE
UDX SaaS endpoint changed in cortx manager

### DIFF
--- a/csm/core/controllers/usl.py
+++ b/csm/core/controllers/usl.py
@@ -85,8 +85,8 @@ class _SecuredView(_View):
 
 
 @Decorators.decorate_if(not Options.debug, _Proxy.on_loopback_only)
-@CsmView._app_routes.view("/api/v1/saas")
-@CsmView._app_routes.view("/api/v2/udx_saas")
+@CsmView._app_routes.view("/usl/v1/saas")
+@CsmView._app_routes.view("/usl/v2/udx_saas")
 class SaaSURLView(_View):
     """
     Lyve Pilot SaaS URL view.

--- a/csm/core/controllers/usl.py
+++ b/csm/core/controllers/usl.py
@@ -85,8 +85,8 @@ class _SecuredView(_View):
 
 
 @Decorators.decorate_if(not Options.debug, _Proxy.on_loopback_only)
-@CsmView._app_routes.view("/usl/v1/saas")
-@CsmView._app_routes.view("/usl/v2/saas")
+@CsmView._app_routes.view("/api/v1/saas")
+@CsmView._app_routes.view("/api/v2/udx_saas")
 class SaaSURLView(_View):
     """
     Lyve Pilot SaaS URL view.


### PR DESCRIPTION
# Backend

## Problem Statement
UDX SaaS endpoint changed in cortx manager
<pre>
Story Ref (if any): 
</pre>
[EOS-18875](https://jts.seagate.com/browse/EOS-18875)
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description 
<pre>
Refer to the ticket.
</pre>
## Solution
<pre>
UDX SaaS endpoint changed in cortx manager to /usl/version/udx_saas format
</pre>
## Unit Test Cases
<pre>
CSM Login:
- Login to CSM UI
- click on lyve-pilot link
- Logged in to S3 account
- selected/created bucket
- Created I am user
- Able to see URL field on csm gui (which is response of udx_saas API)
</pre>
Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>
