### PR TITLE
EOS-18876: Added query parameter support for getting s3_urls from backend for supported schemas - http,https,s3

### DIFF
--- a/csm/common/service_urls.py
+++ b/csm/common/service_urls.py
@@ -60,13 +60,13 @@ class ServiceUrls:
         return uri
 
     @staticmethod
-    def get_s3_uris() -> List[str]:
+    def get_s3_supported_schemas() -> List[str]:
         """
-        Obtains a list of S3 server URIs.
+        Obtains a list of S3 supported schemas.
 
-        :returns: List of S3 server URIs.
+        :returns: List of S3 supported schemas.
         """
-        return [ServiceUrls.get_s3_uri(s) for s in ('http', 'https', 's3')]
+        return ['http', 'https', 's3']
 
     @staticmethod
     def get_bucket_url(bucket_name: str, scheme: str) -> str:

--- a/csm/common/service_urls.py
+++ b/csm/common/service_urls.py
@@ -66,7 +66,7 @@ class ServiceUrls:
 
         :returns: List of S3 server URIs.
         """
-        return [ServiceUrls.get_s3_uri(s) for s in ('http', 'https')]
+        return [ServiceUrls.get_s3_uri(s) for s in ('http', 'https', 's3')]
 
     @staticmethod
     def get_bucket_url(bucket_name: str, scheme: str) -> str:

--- a/csm/core/controllers/s3/server_info.py
+++ b/csm/core/controllers/s3/server_info.py
@@ -38,7 +38,7 @@ class S3ServerInfoView(CsmView):
         """
         Log.debug(f"Handling list s3 buckets fetch request."
                   f" user_id: {self.request.session.credentials.user_id}")
-        schemas = self.request.rel_url.query.get("schemas", None)
+        schemas = self.request.rel_url.query.get("schemas")
         if schemas is not None:
             schemas = schemas.split(',')
         return await self._service.get_s3_server_info(schemas)

--- a/csm/core/controllers/s3/server_info.py
+++ b/csm/core/controllers/s3/server_info.py
@@ -38,4 +38,7 @@ class S3ServerInfoView(CsmView):
         """
         Log.debug(f"Handling list s3 buckets fetch request."
                   f" user_id: {self.request.session.credentials.user_id}")
-        return await self._service.get_s3_server_info()
+        schemas = self.request.rel_url.query.get("schemas", None)
+        if schemas is not None:
+            schemas = schemas.split(',')
+        return await self._service.get_s3_server_info(schemas)

--- a/csm/core/controllers/s3/server_info.py
+++ b/csm/core/controllers/s3/server_info.py
@@ -41,4 +41,4 @@ class S3ServerInfoView(CsmView):
         schemas = self.request.rel_url.query.get("schemas")
         if schemas is not None:
             schemas = schemas.split(',')
-        return await self._service.get_s3_server_info(schemas)
+        return self._service.get_s3_server_info(schemas)

--- a/csm/core/controllers/s3/server_info.py
+++ b/csm/core/controllers/s3/server_info.py
@@ -34,7 +34,7 @@ class S3ServerInfoView(CsmView):
         """
         GET REST implementation for S3 server information request
 
-        :return:
+        :return: s3_urls in json format
         """
         Log.debug(f"Handling list s3 buckets fetch request."
                   f" user_id: {self.request.session.credentials.user_id}")

--- a/csm/core/services/s3/server_info.py
+++ b/csm/core/services/s3/server_info.py
@@ -15,6 +15,7 @@
 
 from csm.common.services import ApplicationService
 from csm.common.service_urls import ServiceUrls
+from csm.common.errors import InvalidRequest
 
 
 class S3ServerInfoService(ApplicationService):
@@ -26,11 +27,14 @@ class S3ServerInfoService(ApplicationService):
         """
         Obtain information about S3 server in json format
         """
+        supported_schemas = ServiceUrls.get_s3_supported_schemas()
         if schemas is not None:
+            if not all(s in supported_schemas for s in schemas):
+                raise InvalidRequest(f'Unsupported schema in list of schemas {schemas}. '
+                    f'Supported schemas are {supported_schemas}')
             s3_urls = [ServiceUrls.get_s3_uri(s) for s in schemas]
         else:
-            s3_urls = [ServiceUrls.get_s3_uri(s) for s in ('http', 'https', 's3')]
-        if s3_urls is not None:
-            return {
-                "s3_urls": s3_urls
-            }
+            s3_urls = [ServiceUrls.get_s3_uri(s) for s in supported_schemas]
+        return {
+            "s3_urls": s3_urls
+        }

--- a/csm/core/services/s3/server_info.py
+++ b/csm/core/services/s3/server_info.py
@@ -22,11 +22,15 @@ class S3ServerInfoService(ApplicationService):
     Service for acessing S3 server information
     """
 
-    async def get_s3_server_info(self):
+    async def get_s3_server_info(self, schemas):
         """
         Obtain information about S3 server in json format
         """
-        s3_urls = ServiceUrls.get_s3_uris()
-        return {
-            "s3_urls": s3_urls
-        }
+        if schemas is not None:
+            s3_urls = [ServiceUrls.get_s3_uri(s) for s in schemas]
+        else:
+            s3_urls = [ServiceUrls.get_s3_uri(s) for s in ('http', 'https', 's3')]
+        if s3_urls is not None:
+            return {
+                "s3_urls": s3_urls
+            }

--- a/csm/core/services/s3/server_info.py
+++ b/csm/core/services/s3/server_info.py
@@ -26,6 +26,8 @@ class S3ServerInfoService(ApplicationService):
     async def get_s3_server_info(self, schemas):
         """
         Obtain information about S3 server in json format
+        :param schemas: List of supported schemas for s3_server_info eg. http,https,s3
+        :returns: s3_urls in json format based on the provided schemas
         """
         supported_schemas = ServiceUrls.get_s3_supported_schemas()
         if schemas is not None:

--- a/csm/core/services/s3/server_info.py
+++ b/csm/core/services/s3/server_info.py
@@ -23,7 +23,7 @@ class S3ServerInfoService(ApplicationService):
     Service for acessing S3 server information
     """
 
-    async def get_s3_server_info(self, schemas):
+    def get_s3_server_info(self, schemas):
         """
         Obtain information about S3 server in json format
         :param schemas: List of supported schemas for s3_server_info eg. http,https,s3


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any):
</pre>
[EOS-18876](https://jts.seagate.com/browse/EOS-18876)
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
On backend, there is a dedicated endpoint ({{GET /api/v1/s3) }}to get s3 URLs. 
But it is not returning the s3 url in the required format s3://ip-address:port. 
</pre>
## Solution
<pre>
Added query parameter support for getting s3_urls from backend for supported schemas - http,https,s3
After merge of this PR, csm_web code should be modified and consume the GET api -
 /api/{version}/s3?schemas=s3 to get the s3_url and add it to the payload of Lyve Pilot registration api.
</pre>
## Unit Test Cases
<pre>

</pre>
![image](https://user-images.githubusercontent.com/36843912/113156737-e400cd80-9257-11eb-96ea-b52e638bad8b.png)
![image](https://user-images.githubusercontent.com/36843912/113156161-5d4bf080-9257-11eb-961b-a5a343ff3585.png)
![image](https://user-images.githubusercontent.com/36843912/113156463-a4d27c80-9257-11eb-9334-ee45d4997386.png)
![image](https://user-images.githubusercontent.com/36843912/113156564-bae03d00-9257-11eb-8eba-eee7fd49b66a.png)
Signed-off-by: 
