### PR TITLE
EOS-19062: Incorporated the changes wrt Singleton MessageBus class

### DIFF
--- a/csm/common/comm.py
+++ b/csm/common/comm.py
@@ -603,10 +603,9 @@ class MessageBusComm(Comm):
     send or receive messages across any component on a node to any other
     component on the other nodes
     """
-    def __init__(self, message_bus):
+    def __init__(self):
         Comm.__init__(self)
         self.message_callback = None
-        self.message_bus = message_bus
         self.producer_id = None
         self.message_type = None
         self.consumer_id = None
@@ -621,7 +620,6 @@ class MessageBusComm(Comm):
         Initializes the producer and consumer communication.
         :param kwargs:
             type: producer|consumer|both(default)
-            message_bus: Instance of MessageBus class
             producer_id: String representing ID that uniquely identifies a producer
             messge_type : This is essentially equivalent to the queue/topic
             name, e.g. "sensor-key"
@@ -658,14 +656,14 @@ class MessageBusComm(Comm):
 
     def _initialize_producer(self):
         """ Initializing Producer """
-        self.producer = MessageProducer(self.message_bus, producer_id=self.producer_id,
+        self.producer = MessageProducer(producer_id=self.producer_id,\
                 message_type=self.message_type, method=self.method)
         Log.info(f"Producer Initialized - Produce ID : {self.producer_id},"\
                 f" Message Type: {self.message_type}, method: {self.method}")
 
     def _initialize_consumer(self):
         """ Initializing Consumer """
-        self.consumer = MessageConsumer(self.message_bus, consumer_id=self.consumer_id,
+        self.consumer = MessageConsumer(consumer_id=self.consumer_id,\
                 consumer_group=self.consumer_group, message_types=self.consumer_message_types,
                 auto_ack=self.auto_ack, offset=self.offset)
         Log.info(f"Consumer Initialized - Consumer ID : {self.consumer_id},"\

--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -73,12 +73,12 @@ class CsmAgent:
             os.remove(f)
 
         #Initializing MessageBus
-        message_bus = None
-        try:
-            #MessageBus needs to be initialized once
-            message_bus = MessageBus()
-        except MessageBusError as ex:
-            Log.error(f"Error occured while initializing MessageBus. {ex}")
+        #message_bus = None
+        #try:
+         #   #MessageBus needs to be initialized once
+         #   message_bus = MessageBus()
+        #except MessageBusError as ex:
+        #    Log.error(f"Error occured while initializing MessageBus. {ex}")
 
         # Alert configuration
         alerts_repository = AlertRepository(db)

--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -72,14 +72,6 @@ class CsmAgent:
         for f in cached_files:
             os.remove(f)
 
-        #Initializing MessageBus
-        #message_bus = None
-        #try:
-         #   #MessageBus needs to be initialized once
-         #   message_bus = MessageBus()
-        #except MessageBusError as ex:
-        #    Log.error(f"Error occured while initializing MessageBus. {ex}")
-
         # Alert configuration
         alerts_repository = AlertRepository(db)
         alerts_service = AlertsAppService(alerts_repository)
@@ -96,7 +88,7 @@ class CsmAgent:
         #Heath configuration
         health_repository = HealthRepository()
         health_plugin = import_plugin_module(const.HEALTH_PLUGIN)
-        health_plugin_obj = health_plugin.HealthPlugin(message_bus)
+        health_plugin_obj = health_plugin.HealthPlugin()
         health_service = HealthAppService(health_repository, alerts_repository, \
             health_plugin_obj)
         CsmAgent.health_monitor = HealthMonitorService(\
@@ -106,7 +98,7 @@ class CsmAgent:
         http_notifications = AlertHttpNotifyService()
         pm = import_plugin_module(const.ALERT_PLUGIN)
         CsmAgent.alert_monitor = AlertMonitorService(alerts_repository,\
-                pm.AlertPlugin(message_bus), CsmAgent.health_monitor.health_plugin, \
+                pm.AlertPlugin(), CsmAgent.health_monitor.health_plugin, \
                 http_notifications)
         email_queue = EmailSenderQueue()
         email_queue.start_worker_sync()
@@ -290,8 +282,6 @@ if __name__ == '__main__':
     from csm.core.services.version import ProductVersionService
     from csm.core.services.appliance_info import ApplianceInfoService
     from csm.core.services.system_status import SystemStatusService
-    from cortx.utils.message_bus import MessageBus
-    from cortx.utils.message_bus.error import MessageBusError
     try:
         # try:
         #     from salt import client

--- a/csm/plugins/cortx/alert.py
+++ b/csm/plugins/cortx/alert.py
@@ -108,10 +108,10 @@ class AlertPlugin(CsmPlugin):
     listening for the alerts.
     """
 
-    def __init__(self, message_bus):
+    def __init__(self):
         super().__init__()
         try:
-            self.comm_client = MessageBusComm(message_bus)
+            self.comm_client = MessageBusComm()
             self.monitor_callback = None
             self.health_plugin = None
             self.mapping_dict = Json(const.ALERT_MAPPING_TABLE).load()

--- a/csm/plugins/cortx/health.py
+++ b/csm/plugins/cortx/health.py
@@ -37,10 +37,10 @@ class HealthPlugin(CsmPlugin):
     listening for the response.
     """
 
-    def __init__(self, message_bus):
+    def __init__(self):
         super().__init__()
         try:
-            self.comm_client = MessageBusComm(message_bus)
+            self.comm_client = MessageBusComm()
             self.health_callback = None
             self._health_mapping_dict = Json(const.HEALTH_MAPPING_TABLE).load()
             storage_request_path = Conf.get(const.CSM_GLOBAL_INDEX, \

--- a/test/message_bus/test_consumer.py
+++ b/test/message_bus/test_consumer.py
@@ -16,13 +16,12 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from csm.common.comm import MessageBusComm
-from cortx.utils.message_bus import MessageBus
 import time
 
 comm_client = None
 
 def init(args):
-    args['message_bus'] = MessageBusComm(MessageBus())
+    pass
 
 def callback_fn(message):
     print(f"Message received: {message}")
@@ -32,7 +31,7 @@ def callback_fn(message):
 def test_recv(args):
     global comm_client
     ret = False
-    message_bus = args['message_bus']
+    message_bus = MessageBusComm()
     comm_client = message_bus
     if message_bus:
         message_bus.init(type='consumer', consumer_id='csm',

--- a/test/message_bus/test_producer.py
+++ b/test/message_bus/test_producer.py
@@ -16,14 +16,13 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from csm.common.comm import MessageBusComm
-from cortx.utils.message_bus import MessageBus
 
 def init(args):
-    args['message_bus'] = MessageBus()
+    pass
 
 def test_send(args):
     ret = False
-    message_bus = MessageBusComm(args['message_bus'])
+    message_bus = MessageBusComm()
     if message_bus:
         message_bus.init(type='producer', producer_id='test_1', message_type='test-1', method='sync')
         messages = []


### PR DESCRIPTION
Signed-off-by: Pawan Kumar Srivastava <pawan.kumarsrivastava@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-19062
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
To ease use of Message Bus, we have made MessageBus class as singleton (not yet part of main branch).
This implies that, one can go ahead without instantiating MessageBus class, or instantiate once or multiple time. All will work. 
The recommended way is not to instantiate MessageBus class.
This brings certain changes in the client classes. Here is the summary of all such changes:
----------------------
MessageBus class is made singleton and it is not necessary to pass MessageBus instance as a parameter to any of the clients i.e., Producer, Consumer or Admin.(It can be included at the end if needed) 
 
All client interfaces are updated and below is the way to initialize all. 
MessageProducer: 
Old: MessageProducer(message_bus, producer_id, message_type, method)  
Updated: MessageProducer(producer_id, message_type, method) (or) 
                 MessageProducer(producer_id, message_type, method, message_bus) (not recommended)
 
MessageConsumer: 
Old: MessageConsumer(message_bus, consumer_id, consumer_group, message_types, auto_ack, offset) 
Updated: MessageConsumer(consumer_id, consumer_group, message_types, auto_ack, offset) (or) 
            MessageConsumer(consumer_id, consumer_group, message_types, auto_ack, offset, message_bus) (not recommended)
 
MessageBusAdmin: 
Old: MessageBusAdmin(message_bus, admin_id) 
Updated: MessageBusAdmin(admin_id) (or) 
                MessageBusAdmin(admin_id, message_bus) (not recommended)
----------------------
</pre>
## Solution
<pre>
Removed the initialization of Messagebus class
</pre>
## Unit Test Cases
<pre>
[root@ssc-vm-c-115 csm]# python3 /opt/seagate/cortx/csm/test/test_framework/csm_test.py -t /opt/seagate/cortx/csm/test/plans/message_bus_producer.pln -f /opt/seagate/cortx/csm/test/test_data/args.yaml

####### Test Suite: message_bus.test_producer ######
message_bus.test_producer:test_send: PASSED (Time: 1s)

***************************************
TestSuite:1 Tests:1 Passed:1 Failed:0 TimeTaken:1s
***************************************
[root@ssc-vm-c-115 csm]# python3 /opt/seagate/cortx/csm/test/test_framework/csm_test.py -t /opt/seagate/cortx/csm/test/plans/message_bus_consuer.pln -f /opt/seagate/cortx/csm/test/test_data/args.yaml

####### Test Suite: message_bus.test_consumer ######
Message received: This is test message number : 0
message_bus.test_consumer:test_recv: PASSED (Time: 2s)

***************************************
TestSuite:1 Tests:1 Passed:1 Failed:0 TimeTaken:2s
***************************************

</pre>
Signed-off-by: 
