### PR TITLE
Audit log fix for msg field

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -160,9 +160,9 @@ class CsmRestApi(CsmApi, ABC):
         method = request.method
         user_agent = request.headers.get('User-Agent')
         entry = {
-            'user': user,
+            'user': user if user else "",
             'remote_ip': remote_ip,
-            'forwarded_for_ip': forwarded_for_ip,
+            'forwarded_for_ip': forwarded_for_ip if forwarded_for_ip else "",
             'method': method,
             'path': path,
             'user_agent': user_agent,

--- a/csm/core/blogic/models/audit_log.py
+++ b/csm/core/blogic/models/audit_log.py
@@ -13,6 +13,7 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
+import time
 from schematics.models import Model
 from schematics.types import DateTimeType, IntType, StringType
 from csm.core.blogic.models import CsmModel
@@ -20,14 +21,15 @@ from csm.core.blogic.models import CsmModel
 class CsmAuditLogModel(CsmModel):
     """ Model for csm audit logs """
     timestamp = DateTimeType()
-    user = StringType()
-    remote_ip = StringType()
-    forwarded_for_ip = StringType()
-    method = StringType()
-    path = StringType()
-    user_agent = StringType()
-    response_code = StringType()
-    request_id = IntType()
+    user = StringType(default="")
+    remote_ip = StringType(default="")
+    forwarded_for_ip = StringType(default="")
+    method = StringType(default="")
+    path = StringType(default="")
+    user_agent = StringType(default="")
+    response_code = StringType(default="")
+    request_id = IntType(default=int(time.time()))
+    msg = StringType(min_length=0, default="")
 
 class S3AuditLogModel(CsmModel):
     """ Model for s3 audit logs """

--- a/csm/plugins/cortx/s3.py
+++ b/csm/plugins/cortx/s3.py
@@ -725,14 +725,14 @@ class IamClient(BaseClient):
         :returns: credentials in case of success, IamError in case of problem
         """
 
-        Log.audit(f"Create access key for user: {user_name}")
+        Log.info(f"Create access key for user: {user_name}")
         params = {}
         if user_name is not None:
             params['UserName'] = user_name
 
         (code, body) = await self._arbitrary_request(
             const.S3_IAM_CMD_CREATE_ACCESS_KEY, params, '/', 'POST')
-        Log.audit(f"Create access key status code: {code}")
+        Log.info(f"Create access key status code: {code}")
         if code != HTTPStatus.CREATED:
             return self._create_error(code, body)
         else:
@@ -752,7 +752,7 @@ class IamClient(BaseClient):
         :returns: true in case of success, IamError in case of problem.
         """
 
-        Log.audit(f"Update access key {access_key_id} for user: {user_name}"
+        Log.info(f"Update access key {access_key_id} for user: {user_name}"
                   f" with status {status}")
         params = {
             'AccessKeyId': access_key_id,
@@ -763,7 +763,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request(
             const.S3_IAM_CMD_UPDATE_ACCESS_KEY, params, '/', 'POST')
-        Log.audit(f"Update access key status code: {code}")
+        Log.info(f"Update access key status code: {code}")
         if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
@@ -780,7 +780,7 @@ class IamClient(BaseClient):
         :returns: timestamp in case of success, IamError in case of problem.
         """
 
-        Log.audit(f"Get last used time of IAM user's {user_name} access key {access_key_id}")
+        Log.info(f"Get last used time of IAM user's {user_name} access key {access_key_id}")
         params = {
             'AccessKeyId': access_key_id
         }
@@ -789,7 +789,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request(
             const.S3_IAM_CMD_GET_ACCESS_KEY_LAST_USED, params, '/', 'POST')
-        Log.audit(f"Update access key status code: {code}")
+        Log.info(f"Update access key status code: {code}")
         if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
@@ -812,7 +812,7 @@ class IamClient(BaseClient):
         :returns: IamAccessKeysListResponse in case of success, IamError otherwise.
         """
 
-        Log.audit(f"List IAM user's {user_name} access keys. marker: {marker},"
+        Log.info(f"List IAM user's {user_name} access keys. marker: {marker},"
                   f" max_items: {max_items}")
         params = {}
         if user_name is not None:
@@ -826,7 +826,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request(
             const.S3_IAM_CMD_LIST_ACCESS_KEYS, params, '/', 'POST')
-        Log.audit(f"List IAM user's access keys status code: {code}")
+        Log.info(f"List IAM user's access keys status code: {code}")
         if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
@@ -859,7 +859,7 @@ class IamClient(BaseClient):
         :returns: true in case of success, IamError in case of problem.
         """
 
-        Log.audit(f"Delete access key {access_key_id} for IAM user {user_name}")
+        Log.info(f"Delete access key {access_key_id} for IAM user {user_name}")
         params = {
             'AccessKeyId': access_key_id
         }


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): msg rough field error is coming.
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
The are some old logs which are not inserted in required json format. which leads to the error and does not display the audit logs.
</pre>
## Solution
<pre>
1. msg field is added in CSMAuditLog Model
2. added default values for all the fields
</pre>
## Unit Test Cases
<pre>
1. Tested by doing S3 operations from UI as well as CLI
2. Tested with Alerts, stats from UI
3. Tested view logs for seven days
4. Tested with downloading audit logs for seven days.
![image](https://user-images.githubusercontent.com/64407225/116083357-26cc8e80-a6ba-11eb-9d50-350f0d0348c7.png)

</pre>
Signed-off-by: Soniya Moholkar <soniya.moholkar@seagate.com>
