### PR TITLE
EOS-14872 and EOS-14907 Invalid response code in exceptions

### DIFF
--- a/csm/common/timeseries.py
+++ b/csm/common/timeseries.py
@@ -263,9 +263,9 @@ class TimelionProvider(TimeSeriesProvider):
         try:
             diff_sec = int(duration_t) - int(from_t)
         except (ValueError, TypeError):
-            raise InvalidRequest(f"from and to time should be integer")
+            raise InvalidRequest(f"'from' and 'to' time should be integer")
         if diff_sec <= 0:
-            raise InvalidRequest("to time should be grater than from time")
+            raise InvalidRequest("'to time' should be grater than 'from time'")
         from_t = int(from_t) - int(self._offset_interval)
         duration_t = int(duration_t) - int(self._offset_interval)
         if total_sample == "" and interval == "":
@@ -274,7 +274,7 @@ class TimelionProvider(TimeSeriesProvider):
             try:
                 interval = str(int(diff_sec / int(total_sample))) + 's'
             except (ValueError, ZeroDivisionError):
-                raise InvalidRequest('total_sample should be integer and greater than zero')
+                raise InvalidRequest("'total_sample' should be integer and greater than zero")
         elif interval != "":
             interval = str(int(interval)) + 's'
         else:

--- a/csm/core/services/stats.py
+++ b/csm/core/services/stats.py
@@ -26,7 +26,7 @@ from datetime import datetime, timedelta
 from typing import Dict
 from cortx.utils.log import Log
 from csm.common.services import Service, ApplicationService
-from csm.common.errors import CsmInternalError
+from csm.common.errors import CsmInternalError, InvalidRequest
 
 STATS_DATA_MSG_NOT_FOUND = "stats_not_found"
 
@@ -130,8 +130,8 @@ class StatsAppService(ApplicationService):
                     panels[li[0]]["unit"].append("")
                 else:
                     panels[li[0]]["unit"].append(li[2])
-        except:
-            raise CsmInternalError("Invalid metric list for Stats %s" %metrics_list)
+        except (IndexError, KeyError):
+            raise InvalidRequest("Invalid metric list for Stats %s" %metrics_list)
 
         if stats_id:
             output["id"]=stats_id


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-14872, https://jts.seagate.com/browse/EOS-14907
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
EOS-14872: GET API for system stats returns 500 for one missing TO and FROM params
EOS-14907: GET API /api/v1/stats returns 500 for invalid values for METRIC and TOTAL_SAMPLE parameter
</pre>
## Solution
<pre>
Raise InvalidRequest exceptions instead CsmInternalError exceptions because parameters are  not valid.
</pre>
## Unit Test Cases
<pre>
Yes
</pre>
Signed-off-by: SrikantVishwakarma <srikant.vishwakarma@seagate.com>