### PR TITLE
EOS:19159 Changes for support_bundle to sync up with other components

### DIFF
--- a/csm/plugins/cortx/provisioner.py
+++ b/csm/plugins/cortx/provisioner.py
@@ -461,7 +461,7 @@ class ProvisionerPlugin:
                       f"cmd_args={repr(command_args)} "
                       f"targets={target_node_id}")
             return self.provisioner.cmd_run(cmd_name=const.CORTXCLI,
-                cmd_args=str(command_args), targets=target_node_id)
+                cmd_args=str(command_args), targets=target_node_id, nowait=True)
         except self.provisioner.errors.ProvisionerError as e:
             Log.error(f"Command Execution error: {e}")
             raise PackageValidationError(f"Command Execution error: {e}")

--- a/schema/commands.yaml
+++ b/schema/commands.yaml
@@ -29,7 +29,6 @@ COMMANDS:
     - '<CORTX_PATH>/motr/conf/setup.yaml'
   hare:
     - '<CORTX_PATH>/hare/conf/setup.yaml'
-    - '<CORTX_PATH>/hare/conf/setup-ha.yaml'
   provisioner:
     - '<CORTX_PATH>/provisioner/conf/setup.yaml'
   manifest:


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any):
</pre>
[EOS-19159](https://jts.seagate.com/browse/EOS-19159)
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
1. Nowait agrument for bundle_generation in provisioner plugin was throwing invalid argument error.
2. setup-ha.yaml has been moved to cortx-ha but setup-ha.yaml file path is still present under hare key in 
commands.yaml
</pre>
## Solution
<pre>
1. As nowait argument error has been fixed from provisioner side, added it back to provisioner plugin in CSM code.
</pre>
[JIRA Ticket ref for provisioner's fix](https://jts.seagate.com/browse/EOS-19561)
<pre>
2. Removed erroneous path of setup-ha.yaml which was nested under hare key in commands.yaml
</pre>
[Ref. for setup-ha.yaml removal](https://jts.seagate.com/browse/EOS-19522?focusedCommentId=2088678&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2088678)
## Unit Test Cases
<pre>
NA
</pre>
Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>
