### PR TITLE
Moving ryslog config to post install

### DIFF
--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -64,7 +64,6 @@ class Configure(Setup):
             self._configure_uds_keys()
             if not self._is_env_vm:
                 Configure._validate_healthmap_path()
-            self._rsyslog()
             self._logrotate()
             self._rsyslog_common()
             for count in range(0, 10):
@@ -133,19 +132,6 @@ class Configure(Setup):
         Conf.save(const.DATABASE_INDEX)
         os.makedirs(const.CSM_CONF_PATH, exist_ok=True)
         Setup._run_cmd(f"cp -rn {const.CSM_SOURCE_CONF_PATH} {const.ETC_PATH}")
-
-    def _rsyslog(self):
-        """
-        Configure rsyslog
-        """
-        Log.info("Configuring rsyslog")
-        os.makedirs(const.RSYSLOG_DIR, exist_ok=True)
-        if os.path.exists(const.RSYSLOG_DIR):
-            Setup._run_cmd(f"cp -f {const.SOURCE_RSYSLOG_PATH} {const.RSYSLOG_PATH}")
-        else:
-            msg = f"rsyslog failed. {const.RSYSLOG_DIR} directory missing."
-            Log.error(msg)
-            raise CsmSetupError(msg)
 
     def _rsyslog_common(self):
         """

--- a/csm/conf/post_install.py
+++ b/csm/conf/post_install.py
@@ -15,6 +15,7 @@
 
 
 import crypt
+import os
 from cortx.utils.log import Log
 from cortx.utils.product_features import unsupported_features
 from cortx.utils.conf_store import Conf

--- a/csm/conf/post_install.py
+++ b/csm/conf/post_install.py
@@ -62,6 +62,7 @@ class PostInstall(Setup):
         self._config_user()
         self._configure_system_auto_restart()
         self._configure_service_user()
+        self._configure_rsyslog()
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
     def _prepare_and_validate_confstore_keys(self):
@@ -160,3 +161,16 @@ class PostInstall(Setup):
         :return:
         """
         Setup._update_service_file("<USER>", self._user)
+
+    def _configure_rsyslog(self):
+        """
+        Configure rsyslog
+        """
+        Log.info("Configuring rsyslog")
+        os.makedirs(const.RSYSLOG_DIR, exist_ok=True)
+        if os.path.exists(const.RSYSLOG_DIR):
+            Setup._run_cmd(f"cp -f {const.SOURCE_RSYSLOG_PATH} {const.RSYSLOG_PATH}")
+        else:
+            msg = f"rsyslog failed. {const.RSYSLOG_DIR} directory missing."
+            Log.error(msg)
+            raise CsmSetupError(msg)


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any):
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>

</pre>
## Solution
<pre>
As per the latest discussion over rsyslog configuration,  decision is made that rsyslog configuration for csm will be moved in post-install
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: 
