### PR TITLE
EOS-19475: Pagination logic corrected for CSM Audit Logs

### DIFF
--- a/csm/core/services/audit_log.py
+++ b/csm/core/services/audit_log.py
@@ -164,8 +164,11 @@ class AuditService(ApplicationService):
         time_range = self.get_date_range_from_duration(int(start_time), int(end_time))
         max_result_window = int(Conf.get(const.CSM_GLOBAL_INDEX, "Log>max_result_window"))
         effective_limit = min(limit, max_result_window) if limit is not None else max_result_window
-        effective_marker = offset if offset is not None else 0
-        query_limit = QueryLimits(effective_limit, effective_marker)
+        query_limit = None
+        if offset is not None and offset > 1:
+            query_limit = QueryLimits(effective_limit, (offset - 1) * effective_limit)
+        else:
+            query_limit = QueryLimits(effective_limit, 0)
 
         if component == const.CSM_COMPONENT_NAME and sort_by not in COMPONENT_MODEL_MAPPING[component][const.SORTABLE_FIELDS]:
             raise InvalidRequest("The specified column cannot be used for sorting",


### PR DESCRIPTION
# Backend

## Problem Statement
<pre>
Story Ref (if any):
</pre>
[EOS-19475](https://jts.seagate.com/browse/EOS-19475)
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
1. offset value was considered as records to be skipped from the entire result set,
instead offset value should have been calculated as per the pageNumber selected on GUI.
Due to this repeated records was getting displayed in the csm audit logs table pages on GUI.
</pre>
## Solution
<pre>
2. Applied formula for offset calculation according to PageNumber selected on GUI.
</pre>
## Unit Test Cases
<pre>
Tested on UI.
<img width="950" alt="1" src="https://user-images.githubusercontent.com/36843912/116968102-7110c980-acd1-11eb-9756-643135486642.png">

<img width="947" alt="2" src="https://user-images.githubusercontent.com/36843912/116968114-78d06e00-acd1-11eb-9fdc-f9b08c0538b6.png">


</pre>
Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>
