### PR TITLE
Merge Main to Stable (#461)

### DIFF
--- a/csm/common/timeseries.py
+++ b/csm/common/timeseries.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 from cortx.utils.conf_store.conf_store import Conf
 from csm.core.blogic import const
 from cortx.utils.log import Log
-from csm.common.errors import CsmError, CsmInternalError
+from csm.common.errors import CsmError, CsmInternalError, InvalidRequest
 from csm.common.payload import *
 
 class TimeSeriesProvider:
@@ -203,11 +203,16 @@ class TimelionProvider(TimeSeriesProvider):
             metric_list, unit_list = await self._get_metric_list(panel, metric_list, unit)
             res = await self._aggregate_metric(panel, from_t, duration_t,
                                             interval, metric_list, query)
-            return await self._convert_payload(res, stats_id, panel, output_format, unit_list)
-        except Exception as e:
+            output = await self._convert_payload(res, stats_id, panel, output_format, unit_list)
+        except InvalidRequest as e:
             Log.debug("Failed to request stats %s" %e)
-            raise CsmInternalError("id: %s, Error: Failed to process timelion "
-                "request %s" %(stats_id,e))
+            raise InvalidRequest("id: %s, Error: Failed to process "
+                "request %s" % (stats_id, e))
+        except CsmInternalError as e:
+            Log.debug("Failed to request stats %s" %e)
+            raise CsmInternalError("id: %s, Error: Failed to process "
+                "request %s" % (stats_id, e))
+        return output
 
     async def get_all_units(self):
         """
@@ -255,15 +260,21 @@ class TimelionProvider(TimeSeriesProvider):
         Check from_t, duration_t time interval and
         calculate interval from total_sample
         """
-        diff_sec = int(duration_t) - int(from_t)
+        try:
+            diff_sec = int(duration_t) - int(from_t)
+        except (ValueError, TypeError):
+            raise InvalidRequest(f"'from' and 'to' time should be integer")
         if diff_sec <= 0:
-            raise CsmInternalError("to time should be grater than from time")
+            raise InvalidRequest("'to time' should be grater than 'from time'")
         from_t = int(from_t) - int(self._offset_interval)
         duration_t = int(duration_t) - int(self._offset_interval)
         if total_sample == "" and interval == "":
             interval = str(self._storage_interval) + 's'
         elif total_sample != "":
-            interval = str(int(diff_sec/int(total_sample))) + 's'
+            try:
+                interval = str(int(diff_sec / int(total_sample))) + 's'
+            except (ValueError, ZeroDivisionError):
+                raise InvalidRequest("'total_sample' should be integer and greater than zero")
         elif interval != "":
             interval = str(int(interval)) + 's'
         else:

--- a/csm/conf/post_install.py
+++ b/csm/conf/post_install.py
@@ -15,6 +15,7 @@
 
 
 import crypt
+import os
 from cortx.utils.log import Log
 from cortx.utils.product_features import unsupported_features
 from cortx.utils.conf_store import Conf
@@ -62,6 +63,7 @@ class PostInstall(Setup):
         self._config_user()
         self._configure_system_auto_restart()
         self._configure_service_user()
+        self._configure_rsyslog()
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
     def _prepare_and_validate_confstore_keys(self):
@@ -160,3 +162,16 @@ class PostInstall(Setup):
         :return:
         """
         Setup._update_service_file("<USER>", self._user)
+
+    def _configure_rsyslog(self):
+        """
+        Configure rsyslog
+        """
+        Log.info("Configuring rsyslog")
+        os.makedirs(const.RSYSLOG_DIR, exist_ok=True)
+        if os.path.exists(const.RSYSLOG_DIR):
+            Setup._run_cmd(f"cp -f {const.SOURCE_RSYSLOG_PATH} {const.RSYSLOG_PATH}")
+        else:
+            msg = f"rsyslog failed. {const.RSYSLOG_DIR} directory missing."
+            Log.error(msg)
+            raise CsmSetupError(msg)

--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -160,9 +160,9 @@ class CsmRestApi(CsmApi, ABC):
         method = request.method
         user_agent = request.headers.get('User-Agent')
         entry = {
-            'user': user,
+            'user': user if user else "",
             'remote_ip': remote_ip,
-            'forwarded_for_ip': forwarded_for_ip,
+            'forwarded_for_ip': forwarded_for_ip if forwarded_for_ip else "",
             'method': method,
             'path': path,
             'user_agent': user_agent,

--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -225,8 +225,8 @@ class CsmAgent:
 
         if not Options.debug:
             CsmAgent._daemonize()
-        CsmAgent.health_monitor.start()
         CsmAgent.alert_monitor.start()
+        CsmAgent.health_monitor.start()
         CsmRestApi.run(port, https_conf, debug_conf)
         Log.info("Started stopping csm agent")
         CsmAgent.alert_monitor.stop()

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -449,6 +449,7 @@ NTP_TIMEZONE_OFFSET = 'ntp_timezone_offset'
 # Audit Log
 AUDIT_LOG = "/tmp/auditlogs/"
 MAX_RESULT_WINDOW = 10000
+SORTABLE_FIELDS = "sortable_fields"
 
 # Syslog constants
 LOG_LEVEL = "INFO"

--- a/csm/core/blogic/models/audit_log.py
+++ b/csm/core/blogic/models/audit_log.py
@@ -13,6 +13,7 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
+import time
 from schematics.models import Model
 from schematics.types import DateTimeType, IntType, StringType
 from csm.core.blogic.models import CsmModel
@@ -20,14 +21,15 @@ from csm.core.blogic.models import CsmModel
 class CsmAuditLogModel(CsmModel):
     """ Model for csm audit logs """
     timestamp = DateTimeType()
-    user = StringType()
-    remote_ip = StringType()
-    forwarded_for_ip = StringType()
-    method = StringType()
-    path = StringType()
-    user_agent = StringType()
-    response_code = StringType()
-    request_id = IntType()
+    user = StringType(default="")
+    remote_ip = StringType(default="")
+    forwarded_for_ip = StringType(default="")
+    method = StringType(default="")
+    path = StringType(default="")
+    user_agent = StringType(default="")
+    response_code = StringType(default="")
+    request_id = IntType(default=int(time.time()))
+    msg = StringType(min_length=0, default="")
 
 class S3AuditLogModel(CsmModel):
     """ Model for s3 audit logs """

--- a/csm/core/controllers/audit_log.py
+++ b/csm/core/controllers/audit_log.py
@@ -29,6 +29,9 @@ class AuditLogRangeQuerySchema(Schema):
 class AuditLogShowQuerySchema(AuditLogRangeQuerySchema):
     limit = fields.Int(validate=validate.Range(min=1))
     offset = fields.Int(validate=validate.Range(min=0))
+    sort_by = fields.Str(data_key='sortby', missing="timestamp", default="timestamp")
+    direction = fields.Str(data_key='dir', validate=validate.OneOf(['desc', 'asc']),
+        missing='desc', default='desc')
 
 @CsmView._app_routes.view("/api/v1/auditlogs/show/{component}")
 @CsmView._app_routes.view("/api/v2/auditlogs/show/{component}")
@@ -56,8 +59,10 @@ class AuditLogShowView(CsmView):
         end_date = request_data["end_date"] 
         limit = request_data.get('limit')
         offset = request_data.get('offset')
+        sort_by = request_data.get('sort_by')
+        direction = request_data.get('direction')
         return await self._service.get_by_range(
-            component, start_date, end_date, limit=limit, offset=offset)
+            component, start_date, end_date, limit=limit, offset=offset, sort_by=sort_by, direction=direction )
 
 @CsmView._app_routes.view("/api/v1/auditlogs/download/{component}")
 @CsmView._app_routes.view("/api/v2/auditlogs/download/{component}")

--- a/csm/core/controllers/s3/accounts.py
+++ b/csm/core/controllers/s3/accounts.py
@@ -125,3 +125,9 @@ class S3AccountsView(S3BaseView):
             response = await self._service.patch_account(self.account_id,
                                                          **patch_body)
             return response
+
+    async def _cleanup_sessions(self):
+        login_service = self.request.app.login_service
+        session_id = self.request.session.session_id
+
+        await login_service.delete_all_sessions(session_id)

--- a/csm/core/services/appliance_info.py
+++ b/csm/core/services/appliance_info.py
@@ -15,6 +15,8 @@
 
 from csm.common.services import ApplicationService
 from cortx.utils.appliance_info.appliance import ApplianceInfo
+from cortx.utils.conf_store.conf_store import Conf
+from csm.core.blogic import const
 
 class ApplianceInfoService(ApplicationService):
     """
@@ -36,4 +38,6 @@ class ApplianceInfoService(ApplicationService):
         ret_dict = {}
         self._appliance_obj.load()
         ret_dict["serial_number"] = self._appliance_obj.get().strip()
+        cluster_id = Conf.get(const.CSM_GLOBAL_INDEX, "PROVISIONER>cluster_id")
+        ret_dict["cluster_id"] = cluster_id
         return [ret_dict]

--- a/csm/core/services/audit_log.py
+++ b/csm/core/services/audit_log.py
@@ -30,8 +30,8 @@ from cortx.utils.data.access import Query, SortOrder
 from csm.core.blogic.models.audit_log import CsmAuditLogModel, S3AuditLogModel
 from csm.common import queries
 from schematics import Model
-from csm.common.errors import CsmNotFoundError
-from typing import Optional, Iterable
+from csm.common.errors import CsmNotFoundError, InvalidRequest
+from typing import Optional, Iterable, Dict
 from cortx.utils.conf_store.conf_store import Conf
 from csm.common.process import SimpleProcess
 
@@ -45,6 +45,7 @@ COMPONENT_MODEL_MAPPING = {
             "{timestamp} {user} {remote_ip} {forwarded_for_ip} {method} {path} {user_agent} "
             "{response_code} {request_id}"
         ),
+        "sortable_fields" : ['timestamp', 'request_id']
     },
     "s3": {
         "model" : S3AuditLogModel,
@@ -55,12 +56,14 @@ COMPONENT_MODEL_MAPPING = {
             "{http_status} {error_code} {bytes_sent} {object_size} {total_time}"
             "{turn_around_time} {referrer} {user_agent} {version_id} {host_id}"
             "{signature_version} {cipher_suite} {authentication_type} {host_header}"
-        )
+        ),
+        "sortable_fields" : ['timestamp']
     }
 }
 
 COMPONENT_NOT_FOUND = "no_audit_log_for_component"
-
+CSM_AUDIT_LOG_MSG_NON_SORTABLE_COLUMN = "csm_audit_log_non_sortable_column"
+S3_AUDIT_LOG_MSG_NON_SORTABLE_COLUMN = "s3_audit_log_non_sortable_column"
 class AuditLogManager():
     def __init__(self, storage: DataBaseProvider):
         self.db = storage
@@ -80,7 +83,7 @@ class AuditLogManager():
         return db_conditions
 
     async def retrieve_by_range(self, component, limits,
-                       time_range: DateTimeRange):
+                       time_range: DateTimeRange, sort: Optional[SortBy] = None):
         query_filter = self._prepare_filters(component, time_range)
         query = Query().filter_by(query_filter)
         if limits and limits.offset:
@@ -88,8 +91,11 @@ class AuditLogManager():
 
         if limits and limits.limit:
             query = query.limit(limits.limit)
-
-        query = query.order_by(COMPONENT_MODEL_MAPPING[component]["field"], "desc")
+        #TO DO: A better solution for sorting in case of show logs and download logs
+        if sort:
+            query = query.order_by(getattr(COMPONENT_MODEL_MAPPING[component]["model"], sort.field), sort.order)
+        else:
+            query = query.order_by(COMPONENT_MODEL_MAPPING[component]["field"], "desc")
         return await self.db(COMPONENT_MODEL_MAPPING[component]["model"]).get(query)
 
     async def count_by_range(self, component,
@@ -146,7 +152,9 @@ class AuditService(ApplicationService):
         end_time: str,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ):
+        sort_by: Optional[str] = None,
+        direction: Optional[str] = None
+    ) -> Dict:
         """ fetch all records for given range from audit log """
         Log.logger.info(f"auditlogs for {component} from {start_time} to {end_time}")
         if not COMPONENT_MODEL_MAPPING.get(component, None):
@@ -156,11 +164,28 @@ class AuditService(ApplicationService):
         time_range = self.get_date_range_from_duration(int(start_time), int(end_time))
         max_result_window = int(Conf.get(const.CSM_GLOBAL_INDEX, "Log>max_result_window"))
         effective_limit = min(limit, max_result_window) if limit is not None else max_result_window
-        effective_marker = offset if offset is not None else 0
-        query_limit = QueryLimits(effective_limit, effective_marker)
+        query_limit = None
+        if offset is not None and offset > 1:
+            query_limit = QueryLimits(effective_limit, (offset - 1) * effective_limit)
+        else:
+            query_limit = QueryLimits(effective_limit, 0)
+
+        if component == const.CSM_COMPONENT_NAME and sort_by not in COMPONENT_MODEL_MAPPING[component][const.SORTABLE_FIELDS]:
+            raise InvalidRequest("The specified column cannot be used for sorting",
+                CSM_AUDIT_LOG_MSG_NON_SORTABLE_COLUMN)
+
+        if component == const.S3_RESOURCE_NAME_S3 and sort_by not in COMPONENT_MODEL_MAPPING[component][const.SORTABLE_FIELDS]:
+            raise InvalidRequest("The specified column cannot be used for sorting",
+                S3_AUDIT_LOG_MSG_NON_SORTABLE_COLUMN)
+
+        sort_options = SortBy(sort_by, SortOrder.ASC if direction == "asc" else SortOrder.DESC)
         audit_logs = await self.audit_mngr.retrieve_by_range(component,
-                                                   query_limit, time_range)
-        return [log.to_primitive() for log in audit_logs]
+                                                   query_limit, time_range, sort_options)
+        audit_logs_count = await self.audit_mngr.count_by_range(component, time_range)
+        return {
+            "total_records": min(audit_logs_count, max_result_window),
+            "logs": [log.to_primitive() for log in audit_logs]
+        }
 
     async def get_audit_log_zip(self, component: str, start_time: str, end_time: str):
         """ get zip file for all records from given range """

--- a/csm/core/services/stats.py
+++ b/csm/core/services/stats.py
@@ -26,7 +26,7 @@ from datetime import datetime, timedelta
 from typing import Dict
 from cortx.utils.log import Log
 from csm.common.services import Service, ApplicationService
-from csm.common.errors import CsmInternalError
+from csm.common.errors import CsmInternalError, InvalidRequest
 
 STATS_DATA_MSG_NOT_FOUND = "stats_not_found"
 
@@ -130,8 +130,8 @@ class StatsAppService(ApplicationService):
                     panels[li[0]]["unit"].append("")
                 else:
                     panels[li[0]]["unit"].append(li[2])
-        except:
-            raise CsmInternalError("Invalid metric list for Stats %s" %metrics_list)
+        except (IndexError, KeyError):
+            raise InvalidRequest("Invalid metric list for Stats %s" %metrics_list)
 
         if stats_id:
             output["id"]=stats_id

--- a/csm/core/services/users.py
+++ b/csm/core/services/users.py
@@ -179,8 +179,6 @@ class CsmUserService(ApplicationService):
         # implement user role management. Replace this hardcoded values
         # with proper constants.
         roles = [const.CSM_SUPER_USER_ROLE, const.CSM_MANAGE_ROLE]
-        if ( Conf.get(const.CSM_GLOBAL_INDEX, "DEPLOYMENT>mode") != const.DEV ):
-            await self._provisioner.create_system_user(user_id, password)
         user = User.instantiate_csm_user(user_id, password, email=email, roles=roles,
                                          alert_notification=True)
         await self.user_mgr.create(user)

--- a/csm/plugins/cortx/health.py
+++ b/csm/plugins/cortx/health.py
@@ -112,10 +112,15 @@ class HealthPlugin(CsmPlugin):
         2. db_update_callback_fn :- This parameter specifies the name of
            HealthMonitor class function to update health map using db.
         """
-        self.health_callback = callback_fn
-        self.db_update_callback = db_update_callback_fn
-        self.comm_client.init(type=const.PRODUCER, producer_id=self._producer_id, \
-                message_type=self._message_type, method=self._method)
+        try:
+            self.health_callback = callback_fn
+            self.db_update_callback = db_update_callback_fn
+            #Adding delay
+            time.sleep(1)
+            self.comm_client.init(type=const.PRODUCER, producer_id=self._producer_id, \
+                    message_type=self._message_type, method=self._method)
+        except Exception as e:
+            Log.error(f"Error occured while calling health plugin init. {e}")
 
     def process_request(self, **kwargs):
         for key, value in kwargs.items():

--- a/csm/plugins/cortx/provisioner.py
+++ b/csm/plugins/cortx/provisioner.py
@@ -461,7 +461,7 @@ class ProvisionerPlugin:
                       f"cmd_args={repr(command_args)} "
                       f"targets={target_node_id}")
             return self.provisioner.cmd_run(cmd_name=const.CORTXCLI,
-                cmd_args=str(command_args), targets=target_node_id)
+                cmd_args=str(command_args), targets=target_node_id, nowait=True)
         except self.provisioner.errors.ProvisionerError as e:
             Log.error(f"Command Execution error: {e}")
             raise PackageValidationError(f"Command Execution error: {e}")

--- a/csm/plugins/cortx/s3.py
+++ b/csm/plugins/cortx/s3.py
@@ -725,14 +725,14 @@ class IamClient(BaseClient):
         :returns: credentials in case of success, IamError in case of problem
         """
 
-        Log.audit(f"Create access key for user: {user_name}")
+        Log.info(f"Create access key for user: {user_name}")
         params = {}
         if user_name is not None:
             params['UserName'] = user_name
 
         (code, body) = await self._arbitrary_request(
             const.S3_IAM_CMD_CREATE_ACCESS_KEY, params, '/', 'POST')
-        Log.audit(f"Create access key status code: {code}")
+        Log.info(f"Create access key status code: {code}")
         if code != HTTPStatus.CREATED:
             return self._create_error(code, body)
         else:
@@ -752,7 +752,7 @@ class IamClient(BaseClient):
         :returns: true in case of success, IamError in case of problem.
         """
 
-        Log.audit(f"Update access key {access_key_id} for user: {user_name}"
+        Log.info(f"Update access key {access_key_id} for user: {user_name}"
                   f" with status {status}")
         params = {
             'AccessKeyId': access_key_id,
@@ -763,7 +763,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request(
             const.S3_IAM_CMD_UPDATE_ACCESS_KEY, params, '/', 'POST')
-        Log.audit(f"Update access key status code: {code}")
+        Log.info(f"Update access key status code: {code}")
         if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
@@ -780,7 +780,7 @@ class IamClient(BaseClient):
         :returns: timestamp in case of success, IamError in case of problem.
         """
 
-        Log.audit(f"Get last used time of IAM user's {user_name} access key {access_key_id}")
+        Log.info(f"Get last used time of IAM user's {user_name} access key {access_key_id}")
         params = {
             'AccessKeyId': access_key_id
         }
@@ -789,7 +789,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request(
             const.S3_IAM_CMD_GET_ACCESS_KEY_LAST_USED, params, '/', 'POST')
-        Log.audit(f"Update access key status code: {code}")
+        Log.info(f"Update access key status code: {code}")
         if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
@@ -812,7 +812,7 @@ class IamClient(BaseClient):
         :returns: IamAccessKeysListResponse in case of success, IamError otherwise.
         """
 
-        Log.audit(f"List IAM user's {user_name} access keys. marker: {marker},"
+        Log.info(f"List IAM user's {user_name} access keys. marker: {marker},"
                   f" max_items: {max_items}")
         params = {}
         if user_name is not None:
@@ -826,7 +826,7 @@ class IamClient(BaseClient):
 
         (code, body) = await self._arbitrary_request(
             const.S3_IAM_CMD_LIST_ACCESS_KEYS, params, '/', 'POST')
-        Log.audit(f"List IAM user's access keys status code: {code}")
+        Log.info(f"List IAM user's access keys status code: {code}")
         if code != HTTPStatus.OK:
             return self._create_error(code, body)
         else:
@@ -859,7 +859,7 @@ class IamClient(BaseClient):
         :returns: true in case of success, IamError in case of problem.
         """
 
-        Log.audit(f"Delete access key {access_key_id} for IAM user {user_name}")
+        Log.info(f"Delete access key {access_key_id} for IAM user {user_name}")
         params = {
             'AccessKeyId': access_key_id
         }

--- a/schema/commands.yaml
+++ b/schema/commands.yaml
@@ -29,7 +29,6 @@ COMMANDS:
     - '<CORTX_PATH>/motr/conf/setup.yaml'
   hare:
     - '<CORTX_PATH>/hare/conf/setup.yaml'
-    - '<CORTX_PATH>/hare/conf/setup-ha.yaml'
   provisioner:
     - '<CORTX_PATH>/provisioner/conf/setup.yaml'
   manifest:

--- a/schema/roles.json
+++ b/schema/roles.json
@@ -21,7 +21,8 @@
             "s3accounts": ["list", "create", "update"],
             "auditlog": ["list", "read"],
             "replace_node": ["list"],
-            "health": ["list"]
+            "health": ["list"],
+            "security": ["read"]
 
         }
     },
@@ -36,7 +37,8 @@
             "s3accounts": ["list"],
             "auditlog": ["list", "read"],
             "replace_node": ["list"],
-            "health": ["list"]
+            "health": ["list"],
+            "security": ["read"]
         }
     },
     "s3": {


### PR DESCRIPTION
* EOS-19358:Changes for s3 account delete issue (#447)

* EOS-19358:Changes for s3 account delete issue

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* EOS-19358:Codacy Fixes

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

* CSM User

* Adding fix for ES issue. (#455)

* Adding temperary fix for ES issue.

Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

* Codacy issue resolved.

Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

* Addressing the comments

Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

* Audit log fix for msg field (#449)

* audit log fix for msg field

Signed-off-by: Soniya Moholkar <soniya.moholkar@seagate.com>

* changed logs from audit to info in s3 plugin

Signed-off-by: Soniya Moholkar <soniya.moholkar@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

* consumer-failure-fix: Fixed connection related issues for messagebus (#456)

* consumer-failure-fix: Fixed connection related issues for messagebus

Signed-off-by: Pawan Kumar Srivastava <pawan.kumarsrivastava@seagate.com>

* consumer-failure-fix: Fixed connection related issues for messagebus

Signed-off-by: Pawan Kumar Srivastava <pawan.kumarsrivastava@seagate.com>

* consumer-failure-fix: Fixed connection related issues for messagebus

Signed-off-by: Pawan Kumar Srivastava <pawan.kumarsrivastava@seagate.com>

* consumer-failure-fix: Fixed connection related issues for messagebus

Signed-off-by: Pawan Kumar Srivastava <pawan.kumarsrivastava@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

* EOS:19159 Changes for support_bundle to sync up with other components (#454)

* EOS-19159:Added nowait param back to provisioner plugin

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* EOS-19159:Removed setup-ha file path nested under hare component

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

* EOS-19475: Sorting implementation for AuditLogShowView on backend (#457)

* EOS-19475: Sorting Implemented for AuditLogShowView

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* EOS-19475:Codacy Fixes

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* EOS-19475: Modifications for sorting implementation on AuditLogShowView

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* EOS-19475: total_records field added in audit_logs response

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* EOS-19475:Changes for total_records field

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* EOS-19475: sortable_fields moved to const.py

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

* EOS-19475: Pagination logic corrected (#460)

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* Moving ryslog config to post install (#458)

* Moving ryslog config to post install

* Moving rsyslog configuration to post_install

* Adding missing import

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

* EOS-19784: About section showing forbidden error to CSM Manage and Monitor users for details api (#459)

Added security read permissoin to Manage and Monitor users.

Signed-off-by: SrikantVishwakarma <srikant.vishwakarma@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

* EOS-14872 and EOS-14907 Invalid response code in exceptions (#453)

* EOS-14872: GET API for system stats returns 500 for one missing TO and FROM params
EOS-14907: GET API /api/v1/stats returns 500 for invalid values for METRIC and TOTAL_SAMPLE parameter

Addressed inappropriate exceptions to yield proper response code and exception

Signed-off-by: SrikantVishwakarma <srikant.vishwakarma@seagate.com>

* Addressed review comments.

Signed-off-by: SrikantVishwakarma <srikant.vishwakarma@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

* EOS-19658: Create API which returns cluster ID (#451)

Updated appliance_info api to return cluster ID as well.

Signed-off-by: SrikantVishwakarma <srikant.vishwakarma@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

Co-authored-by: Rohit Kolapkar <rohit.j.kolapkar@seagate.com>
Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>
Co-authored-by: Udayan Yaragattikar <66424882+udayan-y21@users.noreply.github.com>
Co-authored-by: Soniya <64407225+soniyamoholkar@users.noreply.github.com>
Co-authored-by: Srikant Vishwakamra <45426884+SrikantVishwakarma@users.noreply.github.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any):
</pre>
## Unit testing on RPM done
<pre>
Yes/No
</pre>
## Problem Description
<pre>

</pre>
## Solution
<pre>

</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: 
