### PR TITLE
EOS-20345: USL-Setup integration 

### DIFF
--- a/csm/conf/setup.yaml
+++ b/csm/conf/setup.yaml
@@ -40,3 +40,24 @@ csm:
         cmd: /opt/seagate/cortx/csm/bin/csm_setup reset
         args: --config $URL
 
+usl:
+    post_install:
+        cmd: /opt/seagate/cortx/csm/lib/usl_setup post_install
+        args: --config $URL
+
+    prepare:
+        cmd: /opt/seagate/cortx/csm/lib/usl_setup prepare
+        args: --config $URL
+
+    config:
+        cmd: /opt/seagate/cortx/csm/lib/usl_setup config
+        args: --config $URL
+
+    init:
+        cmd: /opt/seagate/cortx/csm/lib/usl_setup init
+        args: --config $URL
+
+    reset:
+        cmd: /opt/seagate/cortx/csm/lib/usl_setup reset
+        args: --config $URL
+

--- a/csm/conf/usl.py
+++ b/csm/conf/usl.py
@@ -71,8 +71,6 @@ class Usl:
         cert_base_path = Conf.get(Usl.CONSUMER_INDEX, self.conf_store_keys["crt_path_key"])
         PathV().validate('exists', [
             f"dir:{cert_base_path}",
-            f"file:{os.path.join(cert_base_path, Conf.get(Usl.CONSUMER_INDEX, self.conf_store_keys['domain_crt']))}",
-            f"file:{os.path.join(cert_base_path, Conf.get(Usl.CONSUMER_INDEX, self.conf_store_keys['domain_key']))}",
             f"file:{os.path.join(cert_base_path, Conf.get(Usl.CONSUMER_INDEX, self.conf_store_keys['native_crt']))}",
             f"file:{os.path.join(cert_base_path, Conf.get(Usl.CONSUMER_INDEX, self.conf_store_keys['native_key']))}"
         ])

--- a/csm/conf/usl_setup.py
+++ b/csm/conf/usl_setup.py
@@ -179,7 +179,8 @@ def main(argv: dict):
         rc = command.process()
         if rc != 0:
             raise ValueError(f"Failed to run {argv[1]}")
-        return ":PASS"
+        print(":PASS")
+        return 0
     except UslSetupError as e:
         sys.stderr.write("%s\n" % str(e))
         return e.rc()

--- a/csm/core/services/usl_certificate_manager.py
+++ b/csm/core/services/usl_certificate_manager.py
@@ -1,5 +1,4 @@
 # CORTX-CSM: CORTX Management web and CLI interface.
-# CORTX-CSM: CORTX Management web and CLI interface.
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published

--- a/csm/core/services/usl_certificate_manager.py
+++ b/csm/core/services/usl_certificate_manager.py
@@ -1,4 +1,5 @@
 # CORTX-CSM: CORTX Management web and CLI interface.
+# CORTX-CSM: CORTX Management web and CLI interface.
 # Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published
@@ -16,6 +17,7 @@
 from asyncio import Lock
 from csm.core.blogic import const
 from cortx.utils.log import Log
+from cortx.utils.conf_store import Conf
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -157,9 +159,9 @@ class USLNativeCertificateManager(CertificateManager):
 
     def __init__(self) -> None:
         super().__init__(
-            const.UDS_CERTIFICATES_PATH,
-            const.UDS_NATIVE_PRIVATE_KEY_FILENAME,
-            const.UDS_NATIVE_CERTIFICATE_FILENAME,
+            Conf.get(const.USL_GLOBAL_INDEX, 'UDS_CERTIFICATES>cert_path_key'),
+            Conf.get(const.USL_GLOBAL_INDEX, 'UDS_CERTIFICATES>native_key'),
+            Conf.get(const.USL_GLOBAL_INDEX, 'UDS_CERTIFICATES>native_crt'),
         )
 
     # FIXME private key should not be exposed
@@ -181,9 +183,9 @@ class USLDomainCertificateManager(CertificateManager):
 
     def __init__(self, secure_storage: SecureStorage) -> None:
         super().__init__(
-            const.UDS_CERTIFICATES_PATH,
-            const.UDS_DOMAIN_PRIVATE_KEY_FILENAME,
-            const.UDS_DOMAIN_CERTIFICATE_FILENAME,
+            Conf.get(const.USL_GLOBAL_INDEX, 'UDS_CERTIFICATES>cert_path_key'),
+            Conf.get(const.USL_GLOBAL_INDEX, 'UDS_CERTIFICATES>domain_key'),
+            Conf.get(const.USL_GLOBAL_INDEX, 'UDS_CERTIFICATES>domain_crt'),
             secure_storage
         )
 


### PR DESCRIPTION
Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-20345
</pre>
## Unit testing on RPM done
<pre>
Yes
</pre>
## Problem Description
<pre>
Integration with PRovisioner. 
</pre>
## Solution
<pre>
Observation during integration is implemented.
</pre>
## Unit Test Cases
<pre>
"cmd_|-Stage - Post Install USL_|-__slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/csm/conf/setup.yaml', 'usl:post_install')_|-run": {'name': '/opt/seagate/cortx/csm/lib/usl_setup post_install --config json:///opt/seagate/cortx_configs/provisioner_cluster.json', 'changes': {'pid': 38459, 'retcode': 0, 'stdout': ':PASS', 'stderr': ''}, 'result': True, 'comment': 'Command "/opt/seagate/cortx/csm/lib/usl_setup post_install --config json:///opt/seagate/cortx_configs/provisioner_cluster.json" run', '__sls__': 'components.csm.usl.prepare', '__run_num__': 10, 'start_time': '12:50:50.070752', 'duration': 1350.293, '__id__': 'Stage - Post Install USL'}, "cmd_|-Stage - Prepare USL_|-__slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/csm/conf/setup.yaml', 'usl:prepare')_|-run": {'name': '/opt/seagate/cortx/csm/lib/usl_setup prepare --config json:///opt/seagate/cortx_configs/provisioner_cluster.json', 'changes': {'pid': 38499, 'retcode': 0, 'stdout': ':PASS', 'stderr': ''}, 'result': True, 'comment': 'Command "/opt/seagate/cortx/csm/lib/usl_setup prepare --config json:///opt/seagate/cortx_configs/provisioner_cluster.json" run', '__sls__': 'components.csm.usl.prepare', '__run_num__': 11, 'start_time': '12:50:51.421458', 'duration': 537.189, '__id__': 'Stage - Prepare USL'}, 'module_|-Generate TLS certs_|-Generate TLS certs_|-run': {'name': ['csm.generate_csm_tls'], 'changes': {'csm.generate_csm_tls': True}, 'comment': 'csm.generate_csm_tls: True', 'result': True, '__sls__': 'components.csm.usl.prepare', '__run_num__': 12, 'start_time': '12:50:51.962394', 'duration': 3085.385, '__id__': 'Generate TLS certs'}, "cmd_|-Stage - Config USL_|-__slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/csm/conf/setup.yaml', 'usl:config')_|-run": {'name': '/opt/seagate/cortx/csm/lib/usl_setup config --config json:///opt/seagate/cortx_configs/provisioner_cluster.json', 'changes': {'pid': 38660, 'retcode': 0, 'stdout': ':PASS', 'stderr': ''}, 'result': True, 'comment': 'Command "/opt/seagate/cortx/csm/lib/usl_setup config --config json:///opt/seagate/cortx_configs/provisioner_cluster.json" run', '__sls__': 'components.csm.usl.config', '__run_num__': 13, 'start_time': '12:50:55.048238', 'duration': 564.776, '__id__': 'Stage - Config USL'}, "cmd_|-Stage - Init USL_|-__slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/csm/conf/setup.yaml', 'usl:init')_|-run": {'name': '/opt/seagate/cortx/csm/lib/usl_setup init --config json:///opt/seagate/cortx_configs/provisioner_cluster.json', 'changes': {'pid': 38729, 'retcode': 0, 'stdout': ':PASS', 'stderr': ''}, 'result': True, 'comment': 'Command "/opt/seagate/cortx/csm/lib/usl_setup init --config json:///opt/seagate/cortx_configs/provisioner_cluster.json" run', '__sls__': 'components.csm.usl.init_mod', '__run_num__': 14, 'start_time': '12:50:55.613400', 'duration': 558.257, '__id__': 'Stage - Init USL'},
</pre>
Signed-off-by: 
