### PR TITLE
EOS-20670: Create new endpoint that returns audit logs schema

### DIFF
--- a/csm/core/controllers/audit_log.py
+++ b/csm/core/controllers/audit_log.py
@@ -33,6 +33,19 @@ class AuditLogShowQuerySchema(AuditLogRangeQuerySchema):
     direction = fields.Str(data_key='dir', validate=validate.OneOf(['desc', 'asc']),
         missing='desc', default='desc')
 
+
+@CsmView._app_routes.view("/api/v2/auditlogs/schema_info")
+class AuditLogsSchemaInfo(CsmView):
+    def __init__(self, request):
+        super(AuditLogsSchemaInfo, self).__init__(request)
+        self._service = self.request.app["audit_log"]
+        self._service_dispatch = {}
+
+    @CsmAuth.permissions({Resource.AUDITLOG: {Action.LIST}})
+    async def get(self):
+        return await self._service.get_schema_info()
+
+
 @CsmView._app_routes.view("/api/v1/auditlogs/show/{component}")
 @CsmView._app_routes.view("/api/v2/auditlogs/show/{component}")
 class AuditLogShowView(CsmView):

--- a/csm/core/services/audit_log.py
+++ b/csm/core/services/audit_log.py
@@ -125,6 +125,37 @@ class AuditService(ApplicationService):
                                           tzinfo=tz).isoformat()
         return DateTimeRange(start_date, end_date)
 
+    # TODO this is obviously a stub; derive from `CsmAuditLogModel` if possible.
+    async def get_schema_info(self):
+
+        def is_visible(field_id):
+            not_visible = ["remote_ip"]
+            return field_id not in not_visible
+
+        fields = [
+            ["timestamp", "Timestamp", 201],
+            ["user", "User", 301],
+            ["remote_ip", "Remote IP", 401],
+            ["forwarded_for_ip", "Forwarded for IP", 501],
+            ["method", "Method", 601],
+            ["path", "Path", 701],
+            ["user_agent", "User agent", 801],
+            ["response_code", "Response code", 901],
+            ["request_id", "Request ID", 1001],
+            ["msg", "Message", 1101],
+        ]
+        return [
+            {
+                "field_id": f[0],
+                "label": f[1],
+                "display_id": f[2],
+                "display": is_visible(f[0]),
+                "sortable": True,
+                "filterable": False,
+            }
+            for f in fields
+        ]
+
     async def create_audit_log_file(self, file_name, component, time_range):
         """ create audit log file and comrpess to tar.gz """
         try:


### PR DESCRIPTION
# Backend

## Problem Statement

[EOS-20670: Create new endpoint that returns audit logs schema](https://jts.seagate.com/browse/EOS-20670)

See ticket for details.

## Unit testing on RPM done

No

## Problem Description

See ticket for details.

## Solution

### Description

- Implement new endpoint `GET /api/v2/auditlogs/schema_info`, accessible to users with LIST permissions for the Audit Log feature.

### Known issues

None.

## Test Cases

- Endpoint `GET /api/v2/auditlogs/schema_info` should return status code 200 with the following payload:

```
[
  {
    "field_id": "timestamp",
    "label": "Timestamp",
    "display_id": 201,
    "display": true,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "user",
    "label": "User",
    "display_id": 301,
    "display": true,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "remote_ip",
    "label": "Remote IP",
    "display_id": 401,
    "display": false,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "forwarded_for_ip",
    "label": "Forwarded for IP",
    "display_id": 501,
    "display": true,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "method",
    "label": "Method",
    "display_id": 601,
    "display": true,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "path",
    "label": "Path",
    "display_id": 701,
    "display": true,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "user_agent",
    "label": "User agent",
    "display_id": 801,
    "display": true,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "response_code",
    "label": "Response code",
    "display_id": 901,
    "display": true,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "request_id",
    "label": "Request ID",
    "display_id": 1001,
    "display": true,
    "sortable": true,
    "filterable": false
  },
  {
    "field_id": "msg",
    "label": "Message",
    "display_id": 1101,
    "display": true,
    "sortable": true,
    "filterable": false
  }
]
```

