### PR TITLE
EOS-20752: Renaming BaseError class name to UtilsError

### DIFF
--- a/csm/common/errors.py
+++ b/csm/common/errors.py
@@ -15,7 +15,7 @@
 
 import inspect
 
-from cortx.utils.errors import BaseError
+from cortx.utils.errors import UtilsError
 from cortx.utils.log import Log
 
 CSM_OPERATION_SUCESSFUL     = 0x0000
@@ -28,7 +28,7 @@ CSM_SETUP_ERROR             = 0x1006
 CSM_RESOURCE_EXIST          = 0x1007
 CSM_OPERATION_NOT_PERMITTED = 0x1008
 
-class CsmError(BaseError):
+class CsmError(UtilsError):
     """ Parent class for the cli error classes """
 
     def __init__(self, rc=0, desc=None, message_id=None, message_args=None):


### PR DESCRIPTION
Signed-off-by: root <root@ssc-vm-2608.colo.seagate.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any): https://jts.seagate.com/browse/EOS-20752
</pre>
## Unit testing on RPM done
<pre>
No
</pre>
## Problem Description
<pre>
BaseError class was renamed in py-utils and because of this 1 node deployment is failing.
</pre>
## Solution
<pre>
Renamed the class to appropriate one 
</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: 
