### PR TITLE
Tmain to main branch closure

### DIFF
--- a/csm/conf/post_install.py
+++ b/csm/conf/post_install.py
@@ -28,7 +28,7 @@ from csm.core.blogic import const
 from csm.core.providers.providers import Response
 from csm.common.errors import CSM_OPERATION_SUCESSFUL
 from csm.common.payload import Text
-
+from cortx.utils.service.service_handler import Service
 
 class PostInstall(Setup):
     """
@@ -171,6 +171,9 @@ class PostInstall(Setup):
         os.makedirs(const.RSYSLOG_DIR, exist_ok=True)
         if os.path.exists(const.RSYSLOG_DIR):
             Setup._run_cmd(f"cp -f {const.SOURCE_RSYSLOG_PATH} {const.RSYSLOG_PATH}")
+            Log.info("Restarting rsyslog service")
+            service_obj = Service('rsyslog.service')
+            service_obj.restart()
         else:
             msg = f"rsyslog failed. {const.RSYSLOG_DIR} directory missing."
             Log.error(msg)

--- a/experiments/pam/readme.md
+++ b/experiments/pam/readme.md
@@ -18,6 +18,8 @@ please email opensource@seagate.com or cortx-questions@seagate.com.
 
 #### **Required Packages.**
 
+* **gcc**
+    * sudo yum install gcc
 * **pam-devel**
 	* sudo  yum install pam-devel
 * **curl-devel**
@@ -26,24 +28,17 @@ please email opensource@seagate.com or cortx-questions@seagate.com.
 	* sudo yum install json-c-devel
 
 ### **Make PAM FIle **
-    * gcc -fPIC -c pam.c
-    * gcc -shared -o pam_csm.so pam.o -lpam  -lcurl -ljson-c
+    * gcc -fPIC -c pam_cortx.c
+    * gcc -shared -o pam_cortx.so pam_cortx.o -lpam  -lcurl -ljson-c
 
 
 ### **Configuration**
-   
-   1.  add the following line in /etc/pam.d/sshd at starting.
+
+   1.  copy pam_cortx.so to /lib64/security/
+
+   2.  add the following line in /etc/pam.d/password-auth
    ```
-   auth       optional   pam_csm.so
-   ```
-   2.  Add the Following Configuration in /etc/pam.d/system-auth-ac
-   ```
-   auth       optional  pam_csm.so
-   ```
-   3.
-   /etc/pam.d/password-auth 
-   ```
-   auth        sufficient   pam_csm.so
-   account     sufficient   pam_csm.so
-   password    sufficient    pam_csm.so 
+   auth        sufficient    pam_cortx.so   try_first_pass
+   account     sufficient    pam_cortx.so
+   password    sufficient    pam_cortx.so 
    ```


### PR DESCRIPTION
* Correction in csm_agent login url and other minor changes

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* Curl option for failed API response has set to TRUE

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* PAM readme.updated

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* Password prompt issue resolved

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* PAM module renamed to pam_cortx

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* PAM readme updated

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* Removed unnecessary comments

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

* Trying to fix codacy issue

Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

Co-authored-by: kupranay <66459168+kupranay@users.noreply.github.com>

# Backend

## Problem Statement
<pre>
Story Ref (if any):
</pre>
## Unit testing on RPM done
<pre>
Yes/No
</pre>
## Problem Description
<pre>

</pre>
## Solution
<pre>

</pre>
## Unit Test Cases
<pre>

</pre>
Signed-off-by: 


-----
[View rendered experiments/pam/readme.md](https://github.com/Seagate/cortx-manager/blob/t-main/experiments/pam/readme.md)