### PR TITLE
EOS-20670: Remove stale `msg` field from the audit log schema endpoint

### DIFF
--- a/csm/core/services/audit_log.py
+++ b/csm/core/services/audit_log.py
@@ -132,7 +132,6 @@ class AuditService(ApplicationService):
             ["user_agent", "User agent", 801],
             ["response_code", "Response code", 901],
             ["request_id", "Request ID", 1001],
-            ["msg", "Message", 1101],
         ]
         return [
             {


### PR DESCRIPTION
The original PR, #473, was merged before PR #462.  Ideally, it should have been merged after it with the respective updates.  This commit updates it accordingly.

Please see the original PR for reference.
