### PR TITLE
EOS-20545: Showing appropriate error message if invalid Username and Password combinations entered while creating IAM users from cortxcli

### DIFF
--- a/csm/core/controllers/s3/iam_users.py
+++ b/csm/core/controllers/s3/iam_users.py
@@ -103,7 +103,7 @@ class IamUserListView(S3AuthenticatedView):
             body = await self.request.json()
             request_data = schema.load(body, unknown='EXCLUDE')
         except ValidationError as val_err:
-            raise InvalidRequest(_desc=f"Invalid request body: {val_err}")
+            raise InvalidRequest(f"Invalid request body: {val_err}")
         # Create User
         with self._guard_service():
             return await self._service.create_user(self._s3_session,

--- a/csm/core/controllers/s3/iam_users.py
+++ b/csm/core/controllers/s3/iam_users.py
@@ -103,7 +103,7 @@ class IamUserListView(S3AuthenticatedView):
             body = await self.request.json()
             request_data = schema.load(body, unknown='EXCLUDE')
         except ValidationError as val_err:
-            raise InvalidRequest(message_args=f"Invalid request body: {val_err}")
+            raise InvalidRequest(_desc=f"Invalid request body: {val_err}")
         # Create User
         with self._guard_service():
             return await self._service.create_user(self._s3_session,

--- a/csm/core/controllers/validators.py
+++ b/csm/core/controllers/validators.py
@@ -106,8 +106,8 @@ class PasswordValidator(Validator):
                    for each_char in password):
             error.append(f"Must include {''.join(const.PASSWORD_SPECIAL_CHARACTER)}.")
         if error:
-            error_str = "\n".join(error)
-            raise ValidationError(f"Password Policy Not Met.\n{error_str}")
+            error_str = " ".join(error)
+            raise ValidationError(f"Password Policy Not Met. {error_str}")
 
 
 class BucketNameValidator(Validator):


### PR DESCRIPTION
Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

# Backend

# Problem Statement
[EOS-20545](https://jts.seagate.com/browse/EOS-20545)
While creating IAM users using cortxcli, if validation fails for username or password value, generic error message is getting displayed on console - "error(400): Error:- Invalid request message received."
This error message does not indicate which parameter is invalid and creates confusion.

"error(400): Error:- Invalid request message received."
- _Overview: JIRA number/GitHub Issue added to PR: [Y/N]:_ Y
- _Describe the problem this patch intends to solve._

This patch will display appropriate error message if user enters invalid combinations of username & password while creating IAM users using cortxcli.
## Design

- _For Bug describe the fix here._ 
Error description updated in code for above problem description. 
- _For feature, post the link to the solution page._
- _Any northbound interface change and has been notified to other gatekeepers [Y/N]:_ NA


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_ Yes
- _Confirm All CODACY errors are resolved. Yes/No?_ Yes

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_ NA
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_ NA
- _Confirm Testing was performed with installed RPM. Yes/No?_ No
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_ Y

1. Invalid username
![image](https://user-images.githubusercontent.com/36843912/122175669-79981a80-cea1-11eb-827f-00cd78a4a581.png)

2. Invalid Password
![image](https://user-images.githubusercontent.com/36843912/122175770-8ae12700-cea1-11eb-829b-fd39748dba3b.png)

3. Invalid username and password combination
![image](https://user-images.githubusercontent.com/36843912/122175862-9c2a3380-cea1-11eb-9a5a-172ab112aef0.png)

4. Valid username and password combination
![image](https://user-images.githubusercontent.com/36843912/122175917-a9dfb900-cea1-11eb-9228-745d2ac5f401.png)


## Checklist

- _PR is self-reviewed? Yes/No?_ Yes
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_ No
        - _Change notified to other gatekeepers: Yes/No?_ NA
        - _Code reviews done and addressed: Yes/No?_ 
        - _Codacy issues reviewed and addressed: Yes/No?_ Yes
        - _Deployment test : Done/Not?_ Not Done
        - _UT/smoke test: Done/Not?_ UT done
        - _Jira number added to PR: Yes/No?_ Yes
        - _Github merge done using UI: Yes/No?_ 
        - _Side effects on other features - deployment/update/node-replacement_ NA
        - _Changes to quick-start-guide/community impact_ NA
        - _All dependent component code PR are raised or already merged Yes/No_ NA
        - _All dependent code already merged in landing branch Yes/No_ NA
