### PR TITLE
EOS-20811: Keep unsupported features info in `CsmRestApi`

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -99,6 +99,8 @@ class CsmApi(ABC):
 class CsmRestApi(CsmApi, ABC):
     """ REST Interface to communicate with CSM """
 
+    __unsupported_features = None
+
     @staticmethod
     def init(alerts_service):
         CsmApi.init()
@@ -222,8 +224,26 @@ class CsmRestApi(CsmApi, ABC):
         handler = await cls._resolve_handler(request)
         return CsmView.get_permissions(handler, request.method)
 
-    @staticmethod
-    async def check_for_unsupported_endpoint(request):
+    @classmethod
+    async def get_unsupported_features(cls):
+        if cls.__unsupported_features is None:
+            db = unsupported_features.UnsupportedFeaturesDB()
+            cls.__unsupported_features = await db.get_unsupported_features()
+        return cls.__unsupported_features
+
+    @classmethod
+    async def is_feature_supported(cls, component, feature):
+        unsupported_features = await cls.get_unsupported_features()
+        for entry in unsupported_features:
+            if (
+                component == entry[const.COMPONENT_NAME] and
+                feature == entry[const.FEATURE_NAME]
+            ):
+                return False
+        return True
+
+    @classmethod
+    async def check_for_unsupported_endpoint(cls, request):
         """
         Check whether the endpoint is supported. If not, send proper error
         reponse.
@@ -237,13 +257,12 @@ class CsmRestApi(CsmApi, ABC):
         feature_endpoint_map = Json(const.FEATURE_ENDPOINT_MAPPING_SCHEMA).load()
         endpoint = getMatchingEndpoint(feature_endpoint_map, request.path)
         if endpoint:
-            unsupported_feature_instance = unsupported_features.UnsupportedFeaturesDB()
             if endpoint[const.DEPENDENT_ON]:
                 for component in endpoint[const.DEPENDENT_ON]:
-                    if not await unsupported_feature_instance.is_feature_supported(component,endpoint[const.FEATURE_NAME]):
+                    if not await cls.is_feature_supported(component, endpoint[const.FEATURE_NAME]):
                         Log.debug(f"The request {request.path} of feature {endpoint[const.FEATURE_NAME]} is not supported by {component}")
                         raise InvalidRequest("This feature is not supported on this environment.")
-            if not await unsupported_feature_instance.is_feature_supported(const.CSM_COMPONENT_NAME, endpoint[const.FEATURE_NAME]):
+            if not await cls.is_feature_supported(const.CSM_COMPONENT_NAME, endpoint[const.FEATURE_NAME]):
                 Log.debug(f"The request {request.path} of feature {endpoint[const.FEATURE_NAME]} is not supported by {const.CSM_COMPONENT_NAME}")
                 raise InvalidRequest("This feature is not supported on this environment.")
         else:

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -696,6 +696,7 @@ FEATURE_ENDPOINT_MAPPING_SCHEMA = '{}/schema/feature_endpoint_mapping.json'.form
 L18N_SCHEMA = '{}/schema/l18n.json'.format(CSM_PATH)
 DEPENDENT_ON = "dependent_on"
 CSM_COMPONENT_NAME = "csm"
+COMPONENT_NAME = "component_name"
 FEATURE_NAME = "feature_name"
 SETUP_TYPES = "setup_types"
 TYPE = 'type'


### PR DESCRIPTION
# Backend

# Problem Statement

The current implementation queries Elasticsearch at each and every API call to check if the endpoint at hand is supported or not.  This PR queries Elasticsearch only once for details on unsupported features and checks these details instead.

The idea behind this change is to avoid CSM failures related to Elasticsearch timeouts, as described in [EOS-20811](https://jts.seagate.com/browse/EOS-20811).  Please check the ticket for further details.

## Design

- Create new private class variable in `CsmRestApi` to store unsupported features details;
- Iterate over these details at every API call instead of querying Elasticsearch.

## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_
- _Confirm All CODACY errors are resolved. Yes/No?_

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
