### PR TITLE
EOS-18537: modify the audit logs schema endpoint

### DIFF
--- a/csm/core/controllers/audit_log.py
+++ b/csm/core/controllers/audit_log.py
@@ -51,7 +51,7 @@ class AuditLogShowQuerySchema(AuditLogRangeQuerySchema):
         missing='desc', default='desc')
 
 
-@CsmView._app_routes.view("/api/v2/auditlogs/schema_info")
+@CsmView._app_routes.view("/api/v2/auditlogs/schema_info/{component}")
 class AuditLogsSchemaInfo(CsmView):
     def __init__(self, request):
         super(AuditLogsSchemaInfo, self).__init__(request)
@@ -60,7 +60,8 @@ class AuditLogsSchemaInfo(CsmView):
 
     @CsmAuth.permissions({Resource.AUDITLOG: {Action.LIST}})
     async def get(self):
-        return await self._service.get_schema_info()
+        component = self.request.match_info["component"]
+        return await self._service.get_schema_info(component)
 
 
 @CsmView._app_routes.view("/api/v1/auditlogs/show/{component}")
@@ -86,7 +87,7 @@ class AuditLogShowView(CsmView):
                 f"Invalid Range query {str(val_err)}")
 
         start_date = request_data["start_date"]
-        end_date = request_data["end_date"] 
+        end_date = request_data["end_date"]
         limit = request_data.get('limit')
         offset = request_data.get('offset')
         sort_by = request_data.get('sort_by')


### PR DESCRIPTION
# Backend

# Problem Statement

- [EOS-18537](https://jts.seagate.com/browse/EOS-18537)
- Modify the REST endpoint for getting audit logs schema

## Design

- Change /api/v2/auditlogs/schema_info/ to /api/v2/auditlogs/schema_info/**{component}**


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_
- _Confirm All CODACY errors are resolved. Yes/No?_

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
