### PR TITLE
EOS-21280: add data type for timestamp in CSM audit log headers

### DIFF
--- a/csm/core/services/audit_log.py
+++ b/csm/core/services/audit_log.py
@@ -123,7 +123,7 @@ class AuditService(ApplicationService):
             return field_id not in not_visible
 
         fields = [
-            ["timestamp", "Timestamp", 201],
+            ["timestamp", "Timestamp", 201, {"type": "date"}],
             ["user", "User", 301],
             ["remote_ip", "Remote IP", 401],
             ["forwarded_for_ip", "Forwarded for IP", 501],
@@ -134,8 +134,10 @@ class AuditService(ApplicationService):
             ["request_id", "Request ID", 1001],
             ["msg", "Message", 1101],
         ]
-        return [
-            {
+
+        descriptors = []
+        for f in fields:
+            item = {
                 "field_id": f[0],
                 "label": f[1],
                 "display_id": f[2],
@@ -143,8 +145,13 @@ class AuditService(ApplicationService):
                 "sortable": True,
                 "filterable": False,
             }
-            for f in fields
-        ]
+            try:
+                item["value"] = f[3]
+            except IndexError:
+                pass
+            descriptors.append(item)
+
+        return descriptors
 
     async def create_audit_log_file(self, file_name, component, time_range):
         """ create audit log file and comrpess to tar.gz """


### PR DESCRIPTION
# Backend

# Problem Statement

- [EOS-21280](https://jts.seagate.com/browse/EOS-21280)
- Add data type description to the "Timestamp" header of CSM audit logs.

## Design

- The amendment is self-descriptive.

## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_
- _Confirm All CODACY errors are resolved. Yes/No?_

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
