### PR TITLE
EOS-22065: change the Users role filter from 'eq' to 'like'

### DIFF
--- a/csm/core/controllers/users.py
+++ b/csm/core/controllers/users.py
@@ -87,7 +87,7 @@ class CsmGetUsersSchema(Schema):
     username = fields.Str(
         default=None, missing=None,
         validate=validate.Length(min=1, max=const.CSM_USER_NAME_MAX_LEN))
-    role = fields.Str(default=None, missing=None, validate=validate.OneOf(const.CSM_USER_ROLES))
+    role = fields.Str(default=None, missing=None)
 
 
 @CsmView._app_routes.view("/api/v1/csm/users")

--- a/csm/core/services/users.py
+++ b/csm/core/services/users.py
@@ -93,7 +93,7 @@ class UserManager:
             query = query.order_by(getattr(User, sort.field), sort.order)
 
         if role:
-            query_filters.append(Compare(User.role, '=', role))
+            query_filters.append(Compare(User.role, 'like', role))
 
         if username:
             query_filters.append(Compare(User.user_id, 'like', username))


### PR DESCRIPTION
# Backend

# Problem Statement

- [EOS-22065](https://jts.seagate.com/browse/EOS-22065): search and filter for csm users not working as expected.

## Design

- Per Pranay's request changing the Users role filter operation from 'eq' to 'like'.
- Remove the check for the valid User role passed as a role filter.



## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_
- _Confirm All CODACY errors are resolved. Yes/No?_

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
