### PR TITLE
EOS-21280: BE: update sortable fields of CSM audit logs schema

### DIFF
--- a/csm/core/services/audit_log.py
+++ b/csm/core/services/audit_log.py
@@ -133,9 +133,8 @@ class AuditService(ApplicationService):
         :returns: list of audit log field descriptors.
         """
 
-        def is_visible(field_id):
-            not_visible = ["remote_ip"]
-            return field_id not in not_visible
+        not_visible = {"remote_ip"}
+        sortable = {"timestamp", "response_code"}
 
         fields = [
             ["timestamp", "Timestamp", 201, {"type": "date"}],
@@ -152,12 +151,13 @@ class AuditService(ApplicationService):
 
         descriptors = []
         for f in fields:
+            field_name = f[0]
             item = {
-                "field_id": f[0],
+                "field_id": field_name,
                 "label": f[1],
                 "display_id": f[2],
-                "display": is_visible(f[0]),
-                "sortable": True,
+                "display": field_name not in not_visible,
+                "sortable": field_name in sortable,
                 "filterable": False,
             }
             try:


### PR DESCRIPTION
# Backend

# Problem Statement

- [EOS-21280](https://jts.seagate.com/browse/EOS-21280): CSM: audit logs Sorting and filtering enabled.

## Design

- Per Pranay's request make only 'timestamp' and 'response_code' fields sortable.


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_
- _Confirm All CODACY errors are resolved. Yes/No?_

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
