### PR TITLE
EOS-22643: F-11D: Remove admin user creation workflow during preboarding

### DIFF
--- a/csm/core/services/users.py
+++ b/csm/core/services/users.py
@@ -243,11 +243,7 @@ class CsmUserService(ApplicationService):
         creator = await self.user_mgr.get(creator_id) if creator_id else None
         # Perform pre-creation checks for anonymous user
         if creator is None:
-            num_admins = await self.user_mgr.count_admins()
-            if role == const.CSM_SUPER_USER_ROLE and num_admins == 0:
-                Log.info("Anonymous user is creating the first CORTX admin")
-            else:
-                raise CsmPermissionDenied("Please, log in to create a user")
+            raise CsmPermissionDenied("Permission denied.")
         # ... and for logged in user
         else:
             if role == const.CSM_SUPER_USER_ROLE and creator.role != const.CSM_SUPER_USER_ROLE:


### PR DESCRIPTION
# Backend

# Problem Statement
https://jts.seagate.com/browse/EOS-22643
- _Overview: JIRA number/GitHub Issue added to PR: [Y/N]:_
- _Describe the problem this patch intends to solve._

## Design
There will be no first admin creation workflow in CSM agent. as admin will be created during csm_setup config phase
- _For Bug describe the fix here._
- _For feature, post the link to the solution page._
- _Any northbound interface change and has been notified to other gatekeepers [Y/N]:_


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_
- _Confirm All CODACY errors are resolved. Yes/No?_

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
