### PR TITLE
EOS-23138: CSM GUI is not accessible after upgrade

### DIFF
--- a/cicd/cortxcli.spec
+++ b/cicd/cortxcli.spec
@@ -56,6 +56,7 @@ exit 0
 %preun
 
 %postun
+[ $1 -eq 1 ] && exit 0
 rm -f /usr/bin/cortxcli 2> /dev/null;
 rm -f /usr/bin/cli_setup 2> /dev/null;
 rm -rf <CORTXCLI_PATH>/bin/ 2> /dev/null;

--- a/csm/conf/post_upgrade.py
+++ b/csm/conf/post_upgrade.py
@@ -136,16 +136,6 @@ class PostUpgrade(PostInstall, Prepare, Configure, Init, Setup):
         Conf.copy(backup_index, const.CSM_GLOBAL_INDEX, Conf.get_keys(backup_index))
         Conf.save(const.CSM_GLOBAL_INDEX)
 
-        # Restore csm/web/web-dist/.env after upgrade.
-        # Respecting userchanges as well as upgrade changes.
-        # if os.path.exists(const.CSM_WEB_DIST_ENV_FILE_PATH) and \
-        #         os.path.exists(f"{backup_dirname}/.env"):
-        #     Conf.load("env_backup_index", f"properties://{backup_dirname}/.env")
-        #     Conf.load("env_upgrade_index", f"properties://{const.CSM_WEB_DIST_ENV_FILE_PATH}")
-        #     Conf.merge("env_backup_index", "env_upgrade_index")
-        #     Conf.copy("env_backup_index", "env_upgrade_index")
-        #     Conf.save("env_upgrade_index")
-
     def create(self):
         """
         This Function Creates the CSM Conf File on Required Location.

--- a/csm/conf/post_upgrade.py
+++ b/csm/conf/post_upgrade.py
@@ -138,13 +138,13 @@ class PostUpgrade(PostInstall, Prepare, Configure, Init, Setup):
 
         # Restore csm/web/web-dist/.env after upgrade.
         # Respecting userchanges as well as upgrade changes.
-        if os.path.exists(const.CSM_WEB_DIST_ENV_FILE_PATH) and \
-                os.path.exists(f"{backup_dirname}/.env"):
-            Conf.load("env_backup_index", f"properties://{backup_dirname}/.env")
-            Conf.load("env_upgrade_index", f"properties://{const.CSM_WEB_DIST_ENV_FILE_PATH}")
-            Conf.merge("env_backup_index", "env_upgrade_index")
-            Conf.copy("env_backup_index", "env_upgrade_index")
-            Conf.save("env_upgrade_index")
+        # if os.path.exists(const.CSM_WEB_DIST_ENV_FILE_PATH) and \
+        #         os.path.exists(f"{backup_dirname}/.env"):
+        #     Conf.load("env_backup_index", f"properties://{backup_dirname}/.env")
+        #     Conf.load("env_upgrade_index", f"properties://{const.CSM_WEB_DIST_ENV_FILE_PATH}")
+        #     Conf.merge("env_backup_index", "env_upgrade_index")
+        #     Conf.copy("env_backup_index", "env_upgrade_index")
+        #     Conf.save("env_upgrade_index")
 
     def create(self):
         """


### PR DESCRIPTION
# Backend

# Problem Statement
https://jts.seagate.com/browse/EOS-23138
Csm_web not running on managment ip after sw upgrade is performed
## Design
Removed replacing .env file in postupgrade. 


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_y
- _Confirm All CODACY errors are resolved. Yes/No?_y

## Testing
```
021-07-28 07:51:33,019 - INFO - Fire pre-upgrade event (node level)
2021-07-28 07:51:39,966 - INFO - Upgrading sw: '['utils', 'motr', 's3', 'hare', 'ha', 'sspl', 'uds', 'csm']'
2021-07-28 07:51:39,967 - INFO - Upgrading/Installing 'utils' on '['srvnode-1']'
2021-07-28 07:52:09,257 - INFO - Upgrading/Installing 'motr' on '['srvnode-1']'
2021-07-28 07:52:52,000 - INFO - Upgrading/Installing 's3' on '['srvnode-1']'
2021-07-28 07:53:10,414 - INFO - Upgrading/Installing 'hare' on '['srvnode-1']'
2021-07-28 07:53:21,207 - INFO - Upgrading/Installing 'ha' on '['srvnode-1']'
2021-07-28 07:53:35,665 - INFO - Upgrading/Installing 'sspl' on '['srvnode-1']'
2021-07-28 07:54:03,415 - INFO - Upgrading/Installing 'uds' on '['srvnode-1']'
2021-07-28 07:54:15,975 - INFO - Upgrading/Installing 'csm' on '['srvnode-1']'
2021-07-28 07:54:47,464 - INFO - Fire post-upgrade event (node level)
2021-07-28 07:54:56,788 - INFO - Fire post-upgrade event (cluster level)
2021-07-28 07:55:13,028 - INFO - Starting the Cortx cluster
2021-07-28 07:55:15,469 - INFO - [_get_node_group] Node List : ['srvnode-1.data.private']
2021-07-28 07:55:16,353 - INFO - [start] res: {'status': 'InProgress', 'output': 'Node srvnode-1.data.private : Node was in standby mode, Unstandby operation started successfully', 'error': ''}
2021-07-28 07:55:31,381 - INFO - [__init__] Number of nodes configured = 1
2021-07-28 07:55:31,585 - INFO - [_get_pcs_status] pcs status : rc = 0, error =
2021-07-28 07:55:41,607 - INFO - [__init__] Number of nodes configured = 1
2021-07-28 07:55:41,840 - INFO - [_get_pcs_status] pcs status : rc = 0, error =
2021-07-28 07:55:45,027 - INFO - Upgrade is done. Current version of CORTX: '2.0.0-2269'

```
```
[root@ssc-vm-rhev4-0810 ~]# systemctl status csm_web
● csm_web.service - Cluster Controlled csm_web
   Loaded: loaded (/etc/systemd/system/csm_web.service; disabled; vendor preset: disabled)
  Drop-In: /run/systemd/system/csm_web.service.d
           └─50-pacemaker.conf
   Active: active (running) since Wed 2021-07-28 07:55:26 UTC; 5min ago
 Main PID: 1313 (node)
   CGroup: /system.slice/csm_web.service
           └─1313 /opt/nodejs/node-v12.13.0-linux-x64/bin/node /opt/seagate/cortx/csm/web/web-dist/server.js &

Jul 28 07:55:26 ssc-vm-rhev4-0810.colo.seagate.com systemd[1]: Starting Cluster Controlled csm_web...
Jul 28 07:55:26 ssc-vm-rhev4-0810.colo.seagate.com systemd[1]: Started Cluster Controlled csm_web.
Jul 28 07:55:27 ssc-vm-rhev4-0810.colo.seagate.com node[1313]: using ui path  /opt/seagate/cortx/csm/gui/ui-dist
Jul 28 07:55:27 ssc-vm-rhev4-0810.colo.seagate.com node[1313]: Server is running at https://10.230.245.146:443
Jul 28 07:55:27 ssc-vm-rhev4-0810.colo.seagate.com node[1313]: logger: Open WebSocket Server Connetion
[root@ssc-vm-rhev4-0810 ~]# provisioner get_release_version

```
- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_y
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_y
- _Confirm Testing was performed with installed RPM. Yes/No?_y
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_y

## Checklist

- _PR is self-reviewed? Yes/No?_y
- _GitHub Issue is updated_NA
- _Jira is updated_y
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
