### PR TITLE
EOS-23043: fix role for User update command in cortxcli

### DIFF
--- a/csm/cli/schema/users.json
+++ b/csm/cli/schema/users.json
@@ -267,7 +267,6 @@
           "flag": "-r",
           "dest": "role",
           "type": "str",
-          "action": "append",
           "help": "Select an appropriate role for the user.\n Monitor provides viewing access. Manage provides editing access.",
           "choices": [
             "monitor",


### PR DESCRIPTION
# Backend

# Problem Statement

- [EOS-23043](https://jts.seagate.com/browse/EOS-23043)
- User is not able to change role of CSM user using admin login. The following error occurs: Error:- Invalid request body: {'role': ['Not a valid string.']}

## Design

- In CORTXCLI configuration remove the 'append' logiv for the role parameter of the User update command

## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_ Yes
- _Confirm All CODACY errors are resolved. Yes/No?_ Yes

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_ Yes, tested manually
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_ Yes
- _Confirm Testing was performed with installed RPM. Yes/No?_ Yes
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_ Yes, smoke test

## Checklist

- _PR is self-reviewed? Yes/No?_ Yes
- _GitHub Issue is updated_ No
- _Jira is updated_ Yes
  -  _Check if the description is clear and explained._ Yes
    -  _Check Acceptance Criterion is defined._ Yes
      -  _All the tests performed should be mentioned before Resolving a JIRA._ Yes
        -  _Verification needs to be done before marked as Closed/Verified_ Yes
        - _Any interface change Yes/No?_ No
        - _Change notified to other gatekeepers: Yes/No?_ No
        - _Code reviews done and addressed: Yes/No?_ Yes
        - _Codacy issues reviewed and addressed: Yes/No?_ Yes
        - _Deployment test : Done/Not?_ Yes
        - _UT/smoke test: Done/Not?_ Yes
        - _Jira number added to PR: Yes/No?_ Yes
        - _Github merge done using UI: Yes/No?_ Yes
        - _Side effects on other features - deployment/update/node-replacement_ No
        - _Changes to quick-start-guide/community impact_ No
        - _All dependent component code PR are raised or already merged Yes/No_ Yes
        - _All dependent code already merged in landing branch Yes/No_ Yes
