### PR TITLE
EOS-23259: CSM GUI fails to start after Reset

### DIFF
--- a/csm/conf/cleanup.py
+++ b/csm/conf/cleanup.py
@@ -38,8 +38,10 @@ class Cleanup(Setup):
         try:
             Log.info("Loading configuration")
             Conf.load(const.CSM_GLOBAL_INDEX, const.CSM_CONF_URL)
+            Conf.load(const.DATABASE_INDEX, const.DATABASE_CONF_URL)
         except KvError as e:
             Log.error(f"Configuration Loading Failed {e}")
+        await self._unsupported_feature_entry_cleanup()
         self.files_directory_cleanup()
         self.web_env_file_cleanup()
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
@@ -49,7 +51,8 @@ class Cleanup(Setup):
             const.RSYSLOG_PATH,
             const.CSM_LOGROTATE_DEST,
             const.DEST_CRON_PATH,
-            const.CSM_CONF_PATH
+            const.CSM_CONF_PATH,
+            Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path')
         ]
 
         for dir_path in files_directory_list:
@@ -57,5 +60,17 @@ class Cleanup(Setup):
             Setup._run_cmd(f"rm -rf {dir_path}")
 
     def web_env_file_cleanup(self):
-       Log.info(f"Replacing {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl {const.CSM_WEB_DIST_ENV_FILE_PATH}")
-       Setup._run_cmd(f"cp -f {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl {const.CSM_WEB_DIST_ENV_FILE_PATH}")
+       Log.info(f"Replacing {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl " \
+                                    f"{const.CSM_WEB_DIST_ENV_FILE_PATH}")
+       Setup._run_cmd(f"cp -f {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl " \
+                                    f"{const.CSM_WEB_DIST_ENV_FILE_PATH}")
+
+    async def _unsupported_feature_entry_cleanup(self):
+        Log.info("Unsupported feature cleanup")
+        port = Conf.get(const.DATABASE_INDEX, 'databases>es_db>config>port')
+        _es_db_url = (f"http://localhost:{port}/")
+        collection = "config"
+        url = f"{_es_db_url}{collection}/_delete_by_query"
+        payload = {"query": {"match": {"component_name": "csm"}}}
+        Log.info(f"Deleting for collection:{collection} from es_db")
+        await Setup.erase_index(collection, url, "post", payload)

--- a/csm/conf/reset.py
+++ b/csm/conf/reset.py
@@ -89,11 +89,16 @@ class Reset(Setup):
 
     def reset_logs(self):
         Log.info("Reseting log files")
-        log_files = ["csm_agent.log", "csm_middleware.log", "cortxcli.log"]
-        log_files = [os.path.join( Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path'), file)
-                                 for file in log_files]
-        for each_file in log_files:
-            Setup._run_cmd(f"truncate -s 0 {each_file}")
+        log_dir = Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path')
+        csm_log_files = ["csm_agent.log", "csm_middleware.log", "cortxcli.log"]
+        all_log_files = os.listdir(log_dir)
+        for each_file in all_log_files:
+            if each_file in csm_log_files:
+                _file = os.path.join(log_dir, each_file)
+                Setup._run_cmd(f"truncate -s 0 {_file}")
+            else:
+                _file = os.path.join(log_dir, each_file)
+                Setup._run_cmd(f"rm -rf {each_file}")
 
     async def db_cleanup(self):
 

--- a/csm/conf/reset.py
+++ b/csm/conf/reset.py
@@ -15,6 +15,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 import time
+import os
 from cortx.utils.log import Log
 from csm.conf.setup import Setup, CsmSetupError
 from csm.core.providers.providers import Response
@@ -49,7 +50,6 @@ class Reset(Setup):
         self.disable_and_stop_service()
         self.directory_cleanup()
         await self.db_cleanup()
-        await self._unsupported_feature_entry_cleanup()
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
     def disable_and_stop_service(self):
@@ -76,16 +76,20 @@ class Reset(Setup):
 
     def directory_cleanup(self):
         Log.info("Deleting files and folders")
+        log_files = os.listdir(Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path'))
+        log_files = [os.path.join( Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path'), file)
+                                 for file in log_files]
+
         files_directory_list = [
             Conf.get(const.CSM_GLOBAL_INDEX, 'UPDATE>firmware_store_path'),
             Conf.get(const.CSM_GLOBAL_INDEX, 'UPDATE>hotfix_store_path'),
-            const.TMP_CSM,
-            Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path')
-        ]
+            const.TMP_CSM
+            ]
+        files_directory_list.extend(log_files)
 
-        for dir_path in files_directory_list:
-            Log.info(f"Deleting path :{dir_path}")
-            Setup._run_cmd(f"rm -rf {dir_path}")
+        for _path in files_directory_list:
+            Log.info(f"Deleting path :{_path}")
+            Setup._run_cmd(f"rm -rf {_path}")
 
     async def db_cleanup(self):
 
@@ -106,13 +110,6 @@ class Reset(Setup):
 
             Log.info(f"Deleting for collection:{collection} from {db}")
             await self.erase_index(collection, url, "delete")
-
-    async def _unsupported_feature_entry_cleanup(self):
-        collection = "config"
-        url = f"{self._es_db_url}{collection}/_delete_by_query"
-        payload = {"query": {"match": {"component_name": "csm"}}}
-        Log.info(f"Deleting for collection:{collection} from es_db")
-        await self.erase_index(collection, url, "post", payload)
 
     async def erase_index(self, collection, url, method, payload=None):
         Log.info(f"Url: {url}")

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -89,6 +89,21 @@ class Setup:
             raise CsmSetupError(f"Connection to Db Failed. {e}")
 
     @staticmethod
+    async def erase_index(collection, url, method, payload=None):
+        Log.info(f"Url: {url}")
+        try:
+            response, headers, status = await Setup.request(url, method, payload)
+            if status != 200:
+                Log.error(f"Unable to delete collection: {collection}")
+                Log.error(f"Response: {response}")
+                Log.error(f"Status Code: {status}")
+                return None
+        except Exception as e:
+            Log.warn(f"Failed at deleting for {collection}")
+            Log.warn(f"{e}")
+        Log.info(f"Index {collection} Deleted.")
+
+    @staticmethod
     def _validate_conf_store_keys(index, keylist=None):
         if not keylist:
             raise CsmSetupError("Keylist should not be empty")


### PR DESCRIPTION
Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

# Backend

# Problem Statement
https://jts.seagate.com/browse/EOS-23259
Unable to start GUI after Reset phase.
csm_middleware.log was not able to create, as access denied issue observed.

## Design
Modifications in Reset phase:
- Only user created data removed.
- Log files reset done..Not removed.
- Unsupported feature cleanup removed.

Modifications in Cleanup phase:
- Setup created data and config removed.
- Log files directory removed.
- Unsupported feature cleanup.

## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_Y
- _Confirm All CODACY errors are resolved. Yes/No?_Y

## Testing
```
[root@ssc-vm-rhev4-0307 csm]# csm_setup post_install --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS
[root@ssc-vm-rhev4-0307 csm]# csm_setup prepare --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS
[root@ssc-vm-rhev4-0307 csm]# csm_setup config --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS
[root@ssc-vm-rhev4-0307 csm]# csm_setup init --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS

[root@ssc-vm-rhev4-0307 csm]# ls -la  /var/log/seagate/csm/
total 728
drwxrwxr-x+ 2 root    root      4096 Aug  3 11:43 .
drwxrwxr-x+ 9 root    root      4096 Aug  2 17:29 ..
-rw-rwxr--+ 1 root    root       110 Aug  3 07:47 cortxcli.log.1.gz
-rw-r--r--  1 root    root    674751 Aug  3 11:44 csm_agent.log
-rw-r--r--  1 root    root     29121 Aug  3 11:41 csm_agent.log.1.gz
-rw-r--r--  1 cortxub cortxub  19469 Aug  3 11:44 csm_middleware.log
-rw-r--r--  1 cortxub cortxub   2952 Aug  3 11:40 csm_middleware.log.1.gz
[root@ssc-vm-rhev4-0307 csm]# pcs resource disable csm-web
[root@ssc-vm-rhev4-0307 csm]# pcs resource disable csm-agent
[root@ssc-vm-rhev4-0307 csm]# csm_setup reset --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS
[root@ssc-vm-rhev4-0307 csm]# ls -la  /var/log/seagate/csm/
total 8
drwxrwxr-x+ 2 root    root    4096 Aug  3 11:44 .
drwxrwxr-x+ 9 root    root    4096 Aug  2 17:29 ..
-rw-r--r--  1 root    root       0 Aug  3 11:44 csm_agent.log
-rw-r--r--  1 cortxub cortxub    0 Aug  3 11:44 csm_middleware.log
[root@ssc-vm-rhev4-0307 csm]# pcs resource enable csm-agent
[root@ssc-vm-rhev4-0307 csm]# pcs resource enable csm-web
[root@ssc-vm-rhev4-0307 csm]# ls -la  /var/log/seagate/csm/
total 148
drwxrwxr-x+ 2 root    root      4096 Aug  3 11:44 .
drwxrwxr-x+ 9 root    root      4096 Aug  2 17:29 ..
-rw-r--r--  1 root    root    137138 Aug  3 11:45 csm_agent.log
-rw-r--r--  1 cortxub cortxub   3401 Aug  3 11:45 csm_middleware.log
[root@ssc-vm-rhev4-0307 csm]#

[root@ssc-vm-rhev4-0307 csm]# csm_setup cleanup --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS
[root@ssc-vm-rhev4-0307 csm]# ls -la  /var/log/seagate/csm/
ls: cannot access /var/log/seagate/csm/: No such file or directory
```
Reset Log
```
2021-08-03 11:44:54 csm_setup [53858]: INFO [reset_logs] Reseting log files
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Executing cmd: rm -rf csm_middleware.log.1.gz
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Output: ,
 Err:,
 RC:0
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Executing cmd: truncate -s 0 /var/log/seagate/csm/csm_agent.log
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Output: ,
 Err:,
 RC:0
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Executing cmd: truncate -s 0 /var/log/seagate/csm/csm_middleware.log
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Output: ,
 Err:,
 RC:0
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Executing cmd: rm -rf csm_agent.log.1.gz
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Output: ,
 Err:,
 RC:0
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Executing cmd: rm -rf cortxcli.log.1.gz
2021-08-03 11:44:54 csm_setup [53858]: INFO [_run_cmd] Output: ,
 Err:,
 RC:0
                                             
```
Cleanup Logs
```
2021-08-02 15:12:19 csm_setup [30105]: INFO [_unsupported_feature_entry_cleanup] Deleting for collection:config from es_db
2021-08-02 15:12:19 csm_setup [30105]: INFO [erase_index] Url: http://localhost:9200/config/_delete_by_query
2021-08-02 15:12:19 csm_setup [30105]: INFO [erase_index] Index config Deleted.

```

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_y
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_y
- _Confirm Testing was performed with installed RPM. Yes/No?_y
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_y

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
