### PR TITLE
Reset and Cleanup Modificaitons for cluster admin feature

### DIFF
--- a/csm/conf/cleanup.py
+++ b/csm/conf/cleanup.py
@@ -44,6 +44,7 @@ class Cleanup(Setup):
         await self._unsupported_feature_entry_cleanup()
         self.files_directory_cleanup()
         self.web_env_file_cleanup()
+        await self.cluster_admin_cleanup()
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
     def files_directory_cleanup(self):

--- a/csm/conf/cleanup.py
+++ b/csm/conf/cleanup.py
@@ -74,3 +74,14 @@ class Cleanup(Setup):
         payload = {"query": {"match": {"component_name": "csm"}}}
         Log.info(f"Deleting for collection:{collection} from es_db")
         await Setup.erase_index(collection, url, "post", payload)
+
+    async def cluster_admin_cleanup(self):
+        '''
+        Remove User collection from consuldb
+        '''
+        from cortx.utils.data.db.consul_db.storage import CONSUL_ROOT
+        port = Conf.get(const.DATABASE_INDEX, 'databases>consul_db>config>port')
+        collection = "user_collection"
+        url = f"http://localhost:{port}/v1/kv/{CONSUL_ROOT}/{collection}?recurse"
+        Log.info(f"Deleting for collection:{collection} from consul_db")
+        await Setup.erase_index(collection, url, "delete")

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -72,7 +72,7 @@ class Configure(Setup):
         self._configure_cron()
         self._configure_uds_keys()
         self._configure_csm_web_keys()
-        await self._create_cluster_admin()
+        await Setup._create_cluster_admin()
         try:
             for count in range(0, 10):
                 try:
@@ -269,37 +269,3 @@ class Configure(Setup):
             Log.error(f"Error in storing unsupported features: {e_}")
             raise CsmSetupError(f"Error in storing unsupported features: {e_}")
 
-    async def _create_cluster_admin(self):
-        # TODO confstore keys can be changed.
-        Log.info("Creating cluster admin account")
-        cluster_admin_user = Conf.get(const.CONSUMER_INDEX,
-                                    "cortx>software>cluster_credential>username",
-                                    const.DEFAULT_CLUSTER_ADMIN_USER)
-        cluster_admin_secret = Conf.get(const.CONSUMER_INDEX,
-                                    "cortx>software>cluster_credential>secret",
-                                    const.DEFAULT_CLUSTER_ADMIN_PASS)
-        cluster_admin_emailid = Conf.get(const.CONSUMER_INDEX,
-                                    "cortx>software>cluster_credential>emailid",
-                                    const.DEFAULT_CLUSTER_ADMIN_EMAIL)
-
-        UserNameValidator()(cluster_admin_user)
-        PasswordValidator()(cluster_admin_secret)
-
-        conf = GeneralConfig(Yaml(const.DATABASE_CONF).load())
-        db = DataBaseProvider(conf)
-        usr_mngr = UserManager(db)
-        usr_service = CsmUserService(usr_mngr)
-        if (not self.force_action) and \
-            (await usr_service.validate_cluster_admin_create(cluster_admin_user)):
-            Log.console("WARNING: Cortx cluster admin already created.\n"
-                        "Please use '-f' option to create admin user forcefully.")
-            return None
-
-        if self.force_action and await usr_mngr.get(cluster_admin_user):
-            Log.info(f"Removing current user: {cluster_admin_user}")
-            await usr_mngr.delete(cluster_admin_user)
-
-        Log.info(f"Creating cluster admin: {cluster_admin_user}")
-        await usr_service.create_cluster_admin(cluster_admin_user,
-                                                cluster_admin_secret,
-                                                cluster_admin_emailid)

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -72,7 +72,7 @@ class Configure(Setup):
         self._configure_cron()
         self._configure_uds_keys()
         self._configure_csm_web_keys()
-        await Setup._create_cluster_admin()
+        await Setup._create_cluster_admin(self.force_action)
         try:
             for count in range(0, 10):
                 try:

--- a/csm/conf/reset.py
+++ b/csm/conf/reset.py
@@ -42,6 +42,7 @@ class Reset(Setup):
         """
         try:
             Log.info("Loading Url into conf store.")
+            Conf.load(const.CONSUMER_INDEX, command.options.get(const.CONFIG_URL))
             Conf.load(const.CSM_GLOBAL_INDEX, const.CSM_CONF_URL)
             Conf.load(const.DATABASE_INDEX, const.DATABASE_CONF_URL)
         except KvError as e:

--- a/csm/conf/reset.py
+++ b/csm/conf/reset.py
@@ -51,6 +51,7 @@ class Reset(Setup):
         self.reset_logs()
         self.directory_cleanup()
         await self.db_cleanup()
+        await Setup._create_cluster_admin()
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
     def disable_and_stop_service(self):

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -185,7 +185,7 @@ class Setup:
         return csm_user_pass
 
     @staticmethod
-    async def _create_cluster_admin(self):
+    async def _create_cluster_admin(force_action=False):
         '''
         Create Cluster admin using CSM User managment.
         Username, Password, Email will be obtaineed from Confstore
@@ -212,13 +212,13 @@ class Setup:
         db = DataBaseProvider(conf)
         usr_mngr = UserManager(db)
         usr_service = CsmUserService(usr_mngr)
-        if (not self.force_action) and \
+        if (not force_action) and \
             (await usr_service.validate_cluster_admin_create(cluster_admin_user)):
             Log.console("WARNING: Cortx cluster admin already created.\n"
                         "Please use '-f' option to create admin user forcefully.")
             return None
 
-        if self.force_action and await usr_mngr.get(cluster_admin_user):
+        if force_action and await usr_mngr.get(cluster_admin_user):
             Log.info(f"Removing current user: {cluster_admin_user}")
             await usr_mngr.delete(cluster_admin_user)
 

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -184,6 +184,49 @@ class Setup:
                 raise CipherInvalidToken(f"Decryption for CSM Failed. {error}")
         return csm_user_pass
 
+    @staticmethod
+    async def _create_cluster_admin(self):
+        '''
+        Create Cluster admin using CSM User managment.
+        Username, Password, Email will be obtaineed from Confstore
+        '''
+        from csm.core.services.users import CsmUserService, UserManager
+        from cortx.utils.data.db.db_provider import DataBaseProvider, GeneralConfig
+        from csm.core.controllers.validators import PasswordValidator, UserNameValidator
+        # TODO confstore keys can be changed.
+        Log.info("Creating cluster admin account")
+        cluster_admin_user = Conf.get(const.CONSUMER_INDEX,
+                                    "cortx>software>cluster_credential>username",
+                                    const.DEFAULT_CLUSTER_ADMIN_USER)
+        cluster_admin_secret = Conf.get(const.CONSUMER_INDEX,
+                                    "cortx>software>cluster_credential>secret",
+                                    const.DEFAULT_CLUSTER_ADMIN_PASS)
+        cluster_admin_emailid = Conf.get(const.CONSUMER_INDEX,
+                                    "cortx>software>cluster_credential>emailid",
+                                    const.DEFAULT_CLUSTER_ADMIN_EMAIL)
+
+        UserNameValidator()(cluster_admin_user)
+        PasswordValidator()(cluster_admin_secret)
+
+        conf = GeneralConfig(Yaml(const.DATABASE_CONF).load())
+        db = DataBaseProvider(conf)
+        usr_mngr = UserManager(db)
+        usr_service = CsmUserService(usr_mngr)
+        if (not self.force_action) and \
+            (await usr_service.validate_cluster_admin_create(cluster_admin_user)):
+            Log.console("WARNING: Cortx cluster admin already created.\n"
+                        "Please use '-f' option to create admin user forcefully.")
+            return None
+
+        if self.force_action and await usr_mngr.get(cluster_admin_user):
+            Log.info(f"Removing current user: {cluster_admin_user}")
+            await usr_mngr.delete(cluster_admin_user)
+
+        Log.info(f"Creating cluster admin: {cluster_admin_user}")
+        await usr_service.create_cluster_admin(cluster_admin_user,
+                                                cluster_admin_secret,
+                                                cluster_admin_emailid)
+
     def _is_user_exist(self):
         """
         Check if user exists


### PR DESCRIPTION
# Backend

# Problem Statement

- _Overview: JIRA number/GitHub Issue added to PR: [Y/N]:_NA
- _Describe the problem this patch intends to solve._

## Design

Reset Phase:
- Cleanup Consul db
- Re create Cluster admin with default password from Confstore.

Cleanup Phase:
- Cleanup all consul data..including CLuster admin  

## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_Y
- _Confirm All CODACY errors are resolved. Yes/No?_Y

## Testing
```
[root@ssc-vm-rhev4-0906 731368]# csm_setup post_install --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS
[root@ssc-vm-rhev4-0906 731368]#  csm_setup prepare --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS
[root@ssc-vm-rhev4-0906 731368]# csm_setup config --config json:///opt/seagate/cortx_configs/provisioner_cluster.json -f
:PASS
[root@ssc-vm-rhev4-0906 731368]# csm_setup init --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS

[root@ssc-vm-rhev4-0906 731368]# pcs resource enable csm-web
[root@ssc-vm-rhev4-0906 731368]# pcs resource enable csm-agent

[root@ssc-vm-rhev4-0906 731368]# consul kv get -recurse /cortx/base/
cortx/base/user_collection:2021-08-04 16:58:04.106054
cortx/base/user_collection/obj:{"user_id": null, "user_type": null, "role": null, "password_hash": null, "email": null, "reset_password": null, "alert_notification": null, "updated_time": null, "created_time": null}

cortx/base/user_collection/obj/admin:{"user_id": "admin", "user_type": "csm", "role": "admin", "password_hash": "$2b$12$1nR/QwbPhtboCz/6qaGV0uc1Of8w4mJ6YVnBhxfZmBJeZI8X2Wuai", "email": "admin@seagate.com", "reset_password": false, "alert_notification": true, "updated_time": "2021-08-04T17:31:08.855397+0000", "created_time": "2021-08-04T17:31:08.855364+0000"}

cortx/base/user_collection/obj/cortxadmin:{"user_id": "cortxadmin", "user_type": "csm", "role": "admin", "password_hash": "$2b$12$aS3/Dgs54sv5gq/xARjKJu7jSWwH.M6ROw4R255dV.7HyyWyhw.fW", "email": "cortxadmin@seagate.com", "reset_password": false, "alert_notification": true, "updated_time": "2021-08-04T17:19:24.402455+0000", "created_time": "2021-08-04T17:19:24.402436+0000"}

cortx/base/user_collection/obj/manager1:{"user_id": "manager1", "user_type": "csm", "role": "manage", "password_hash": "$2b$12$YT9FyM8wn4oW9yK/ouUkWOhpa223fTM8.9vpypIxfDXtm19BquJqG", "email": "admin@seagate.com", "reset_password": false, "alert_notification": true, "updated_time": "2021-08-04T17:32:10.971241+0000", "created_time": "2021-08-04T17:32:10.971213+0000"}

cortx/base/user_collection/obj/monitor1:{"user_id": "monitor1", "user_type": "csm", "role": "monitor", "password_hash": "$2b$12$dkqAS1tLL1OG5qtzVu.2RuEp4wNDzR64xEwEyIDlh3ECcSOZUJGOm", "email": "admin@seagate.com", "reset_password": false, "alert_notification": true, "updated_time": "2021-08-04T17:31:49.401092+0000", "created_time": "2021-08-04T17:31:49.401060+0000"}

cortx/base/usl_api_key:2021-08-04 17:23:53.846670
cortx/base/usl_api_key/obj:{"key": null}
cortx/base/usl_api_key/obj/4f3b2f55-702b-493f-9a79-691779165520:{"key": "4f3b2f55-702b-493f-9a79-691779165520"}

[root@ssc-vm-rhev4-0906 731368]# pcs resource disable csm-agent
[root@ssc-vm-rhev4-0906 731368]# pcs resource disable csm-web

[root@ssc-vm-rhev4-0906 731368]# csm_setup reset --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS

[root@ssc-vm-rhev4-0906 731368]# consul kv get -recurse /cortx/base/
cortx/base/user_collection:2021-08-04 17:33:52.776168
cortx/base/user_collection/obj:{"user_id": null, "user_type": null, "role": null, "password_hash": null, "email": null, "reset_password": null, "alert_notification": null, "updated_time": null, "created_time": null}

cortx/base/user_collection/obj/cortxadmin:{"user_id": "cortxadmin", "user_type": "csm", "role": "admin", "password_hash": "$2b$12$nI8lMJR4MN2CeWkdF7eg3ekZYcegtdANzmo.5JPdzZhPR3ylOEaBm", "email": "cortxadmin@seagate.com", "reset_password": false, "alert_notification": true, "updated_time": "2021-08-04T17:33:53.077768+0000", "created_time": "2021-08-04T17:33:53.077752+0000"}

[root@ssc-vm-rhev4-0906 731368]# csm_setup cleanup --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS

[root@ssc-vm-rhev4-0906 731368]# consul kv get -recurse /cortx/base/
[root@ssc-vm-rhev4-0906 731368]#

```
Reset Log
```
2021-08-04 17:33:52 csm_setup [17889]: INFO [db_cleanup] Deleting for collection:user_collection from consul_db
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Url: http://localhost:8500/v1/kv/cortx/base/user_collection?recurse
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Index user_collection Deleted.
2021-08-04 17:33:52 csm_setup [17889]: INFO [db_cleanup] Deleting for collection:system_config from consul_db
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Url: http://localhost:8500/v1/kv/cortx/base/system_config?recurse
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Index system_config Deleted.
2021-08-04 17:33:52 csm_setup [17889]: INFO [db_cleanup] Deleting for collection:usl_volume_collection from consul_db
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Url: http://localhost:8500/v1/kv/cortx/base/usl_volume_collection?recurse
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Index usl_volume_collection Deleted.
2021-08-04 17:33:52 csm_setup [17889]: INFO [db_cleanup] Deleting for collection:onboarding_config from consul_db
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Url: http://localhost:8500/v1/kv/cortx/base/onboarding_config?recurse
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Index onboarding_config Deleted.
2021-08-04 17:33:52 csm_setup [17889]: INFO [db_cleanup] Deleting for collection:product_licenses from consul_db
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Url: http://localhost:8500/v1/kv/cortx/base/product_licenses?recurse
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Index product_licenses Deleted.
2021-08-04 17:33:52 csm_setup [17889]: INFO [db_cleanup] Deleting for collection:appliance_name from consul_db
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Url: http://localhost:8500/v1/kv/cortx/base/appliance_name?recurse
2021-08-04 17:33:52 csm_setup [17889]: INFO [erase_index] Index appliance_name Deleted.


2021-08-04 17:33:52 csm_setup [17889]: INFO [_create_cluster_admin] Creating cluster admin account
2021-08-04 17:33:52 csm_setup [17889]: INFO [_create_cluster_admin] Creating cluster admin: cortxadmin

```
Cleanup Log
```
2021-08-04 17:36:41 csm_setup [22360]: INFO [cluster_admin_cleanup] Deleting for collection:user_collection from consul_db
2021-08-04 17:36:41 csm_setup [22360]: INFO [erase_index] Url: http://localhost:8500/v1/kv/cortx/base/user_collection?recurse
2021-08-04 17:36:41 csm_setup [22360]: INFO [erase_index] Index user_collection Deleted.

```
- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_Y
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_Y
- _Confirm Testing was performed with installed RPM. Yes/No?_Y
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_Y

## Checklist

- _PR is self-reviewed? Yes/No?_Y
- _GitHub Issue is updated_NA
- _Jira is updated_NA
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
