### PR TITLE
EOS-22891:  LIKE filter for ElasticSearch queries 

### DIFF
--- a/csm/common/filter.py
+++ b/csm/common/filter.py
@@ -17,6 +17,7 @@ from cortx.utils.data.access.filters import Compare, And, Or
 from schematics.exceptions import ConversionError
 from csm.core.blogic.models import CsmModel
 from csm.common.errors import InvalidRequest
+from schematics.types import StringType
 import urllib.parse
 import re
 
@@ -74,7 +75,10 @@ class Filter:
         nested_operations = 0
         filter_obj = []
         for key, value in query.items():
-            db_conditions.append(Compare(eval(f"model.{key}"), "=", value))
+            if (type(getattr(model, key))) is StringType:
+                db_conditions.append(Compare(eval(f"model.{key}"), "like", value))
+            else:
+                db_conditions.append(Compare(eval(f"model.{key}"), "=", value))
             if len(db_conditions) > 1:
                 filter_obj.clear()
                 if operations[nested_operations] == "AND":

--- a/csm/common/filter.py
+++ b/csm/common/filter.py
@@ -75,7 +75,7 @@ class Filter:
         nested_operations = 0
         filter_obj = []
         for key, value in query.items():
-            if (type(getattr(model, key))) is StringType:
+            if isinstance(getattr(model, key), StringType):
                 db_conditions.append(Compare(eval(f"model.{key}"), "like", value))
             else:
                 db_conditions.append(Compare(eval(f"model.{key}"), "=", value))


### PR DESCRIPTION
Signed-off-by: Pranali04796 <pranali.ugale@seagate.com>

# Backend

# Problem Statement

- Overview: EOS-22891:LIKE filter for Elasticsearch queries
- Currently the cortx-utils data framework does not support 'LIKE' operator for partial search. Elasticsearch supports full-text search which is used.
## Design

- Implementation of like operator for StringType is implemented in py-utils [#444](https://github.com/Seagate/cortx-utils/pull/444)

## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_: yes
- _Confirm All CODACY errors are resolved. Yes/No?: No 

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_:  Yes
- _Confirm all the unit/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_: Yes
- _GitHub Issue is updated yes
- _Jira is updated_ : yes
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_

<img width="834" alt="op2" src="https://user-images.githubusercontent.com/68841079/128867830-ee95fcb6-b3a9-4e29-ae43-fa27e8e7df32.PNG">
<img width="844" alt="op6" src="https://user-images.githubusercontent.com/68841079/128867914-b106414b-1a90-4c7f-a1fa-cb6dd516e10b.PNG">
<img width="842" alt="op4" src="https://user-images.githubusercontent.com/68841079/128868015-5726a94b-496b-4e86-a276-c4b91d09f2b0.PNG">
<img width="733" alt="build success" src="https://user-images.githubusercontent.com/68841079/128868079-6f2e4531-c2a7-4258-96f5-ee8499a23f72.PNG">


