### PR TITLE
EOS-23135: Passing invalid interval parameter in the GET stats query returns 200

### DIFF
--- a/csm/common/timeseries.py
+++ b/csm/common/timeseries.py
@@ -273,12 +273,17 @@ class TimelionProvider(TimeSeriesProvider):
         elif total_sample != "":
             try:
                 interval = str(int(diff_sec / int(total_sample))) + 's'
-            except (ValueError, ZeroDivisionError):
+            except (ValueError, ZeroDivisionError, TypeError):
                 raise InvalidRequest("'total_sample' should be integer and greater than zero")
         elif interval != "":
-            interval = str(int(interval)) + 's'
-        else:
-            raise CsmInternalError("Unable to parse interval")
+            try:
+                interval = int(interval)
+                if interval < 1:
+                    raise InvalidRequest("'interval' should be integer and greater than zero")
+                else:
+                    interval = str(int(interval)) + 's'
+            except (ValueError, TypeError):
+                raise InvalidRequest("'interval' should be integer and greater than zero")
         return interval, duration_t, from_t
 
     async def _update_index(self, metric, from_t, duration_t):


### PR DESCRIPTION
# Backend

# Problem Statement

EOS-23135: Passing invalid interval parameter in the GET stats query returns 200

- _Overview: JIRA number/GitHub Issue added to PR: [Y/N]:_Y
- _Describe the problem this patch intends to solve._
Passing invalid interval parameter in the GET stats query returns 200, it should return 400 response code.

## Design

- _For Bug describe the fix here._
- _For feature, post the link to the solution page._
- _Any northbound interface change and has been notified to other gatekeepers [Y/N]:_


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_ Yes
- _Confirm All CODACY errors are resolved. Yes/No?_ Yes

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_ No
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_ No
- _Confirm Testing was performed with installed RPM. Yes/No?_ No
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_ Yes

## Checklist

- _PR is self-reviewed? Yes/No?_ Yes
- _GitHub Issue is updated_ 
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_ No
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_ Yes
        - _Codacy issues reviewed and addressed: Yes/No?_ Yes
        - _Deployment test : Done/Not?_ Not
        - _UT/smoke test: Done/Not?_ Done
        - _Jira number added to PR: Yes/No? Yes_
        - _Github merge done using UI: Yes/No?_ No
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
