### PR TITLE
EOS-24103: Remove the SystemD dependency

### DIFF
--- a/cicd/csm_agent.spec
+++ b/cicd/csm_agent.spec
@@ -56,8 +56,6 @@ PRODUCT=<PRODUCT>
 
     ln -sf $CSM_DIR/lib/csm_cleanup /usr/bin/csm_cleanup
     ln -sf $CSM_DIR/lib/csm_cleanup $CSM_DIR/bin/csm_cleanup
-
-    cp -f $CFG_DIR/service/csm_agent.service /etc/systemd/system/csm_agent.service
 }
 
 [ -d "${CSM_DIR}/test" ] && {
@@ -71,19 +69,23 @@ exit 0
 
 %preun
 [ $1 -eq 1 ] && exit 0
-systemctl disable csm_agent
-systemctl stop csm_agent
+[ -f /etc/systemd/system/csm_agent.service ] && {
+    systemctl disable csm_agent
+    systemctl stop csm_agent
+}
 
 %postun
 [ $1 -eq 1 ] && exit 0
-rm -f /etc/systemd/system/csm_agent.service 2> /dev/null;
 rm -f /usr/bin/csm_setup 2> /dev/null;
 rm -f /usr/bin/usl_setup 2> /dev/null;
 rm -f /usr/bin/csm_agent 2> /dev/null;
 rm -f /usr/bin/csm_test 2> /dev/null;
 rm -f /usr/bin/csm_cleanup 2> /dev/null;
 rm -rf <CSM_PATH>/bin/ 2> /dev/null;
-systemctl daemon-reload
+[ -f /etc/systemd/system/csm_agent.service ] && {
+    rm -f /etc/systemd/system/csm_agent.service 2> /dev/null;
+    systemctl daemon-reload
+}
 exit 0
 
 %clean

--- a/csm/conf/post_install.py
+++ b/csm/conf/post_install.py
@@ -63,6 +63,7 @@ class PostInstall(Setup):
         self._prepare_and_validate_confstore_keys()
         self._set_deployment_mode()
         self.validate_3rd_party_pkgs()
+        self._copy_systemd_configuration()
         self._config_user()
         if Conf.get(const.CONSUMER_INDEX, 'systemd>csm>csm_agent>restart_on_failure') == 'true':
             self._configure_system_auto_restart()
@@ -164,7 +165,7 @@ class PostInstall(Setup):
         if any(is_auto_restart_required):
             Log.debug("Updating All setup file for Auto Restart on "
                       "Failure")
-            Setup._update_csm_files("#< RESTART_OPTION >",
+            Setup._update_systemd_conf("#< RESTART_OPTION >",
                                        "Restart=on-failure")
             Setup._run_cmd("systemctl daemon-reload")
 
@@ -173,7 +174,7 @@ class PostInstall(Setup):
         Configures the Service user in CSM service files.
         :return:
         """
-        Setup._update_csm_files("<USER>", self._user)
+        Setup._update_systemd_conf("<USER>", self._user)
 
     def _configure_rsyslog(self):
         """

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -146,8 +146,10 @@ DATABASE_CONF = '/etc/csm/database.yaml'
 DATABASE_CONF_URL = f"yaml://{DATABASE_CONF}"
 DATABASE_CLI_CONF = '/etc/cli/database_cli.yaml'
 CSM_AGENT_SERVICE = "csm_agent.service"
+CSM_AGENT_SERVICE_SRC_PATH = f"{CSM_PATH}/conf/service/{CSM_AGENT_SERVICE}"
 CSM_AGENT_SERVICE_FILE_PATH = f"/etc/systemd/system/{CSM_AGENT_SERVICE}"
 CSM_WEB_SERVICE = "csm_web.service"
+CSM_WEB_SERVICE_SRC_PATH = f"{CSM_PATH}/conf/service/{CSM_WEB_SERVICE}"
 CSM_WEB_SERVICE_FILE_PATH = f"/etc/systemd/system/{CSM_WEB_SERVICE}"
 CSM_WEB_ENV_FILE_PATH = f"{BASE_DIR}/csm/web/.env"
 CSM_WEB_DIST_ENV_FILE_PATH = f"{BASE_DIR}/csm/web/web-dist/.env"
@@ -637,6 +639,7 @@ DEV = 'dev'
 VM = 'VM'
 VIRTUAL = 'virtual'
 ENV_TYPE = 'env_type'
+ENV_TYPE_KEY = 'cortx>common>environment_type'
 
 # System config list
 SYSCONFIG_TYPE = ['management_network_settings', 'data_network_settings',


### PR DESCRIPTION
# Backend

# Problem Statement

- [EOS-24103](https://jts.seagate.com/browse/EOS-24103)
- Remove systemd configuration from csm_setup.

## Design

- Make the SystemD configuration conditional basing on the Confstore key value (details are in JIRA).


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_ Yes
- _Confirm All CODACY errors are resolved. Yes/No?_ Yes

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_ Yes
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_ Yes
- _Confirm Testing was performed with installed RPM. Yes/No?_ Yes, smoke test
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_ Y

## Checklist

- _PR is self-reviewed? Yes/No?_ Yes
- _GitHub Issue is updated_
- _Jira is updated_ Yes
  -  _Check if the description is clear and explained._ Yes
    -  _Check Acceptance Criterion is defined._ Yes
      -  _All the tests performed should be mentioned before Resolving a JIRA._ Yes
        -  _Verification needs to be done before marked as Closed/Verified_ No
        - _Any interface change Yes/No?_ No
        - _Change notified to other gatekeepers: Yes/No?_ No
        - _Code reviews done and addressed: Yes/No?_ Yes
        - _Codacy issues reviewed and addressed: Yes/No?_ Yes
        - _Deployment test : Done/Not?_ Yes
        - _UT/smoke test: Done/Not?_ Yes
        - _Jira number added to PR: Yes/No?_ Yes
        - _Github merge done using UI: Yes/No?_ Yes
        - _Side effects on other features - deployment/update/node-replacement_ No
        - _Changes to quick-start-guide/community impact_ No
        - _All dependent component code PR are raised or already merged Yes/No_ Yes
        - _All dependent code already merged in landing branch Yes/No_ Yes
