### PR TITLE
F-97D: Pre-factory option in cleanup interface.

### DIFF
--- a/csm/cli/schema/csm_setup.json
+++ b/csm/cli/schema/csm_setup.json
@@ -399,6 +399,12 @@
             "help": "Config Store URL e.g <type>://<path>."
           },
           {
+            "flag": "--pre-factory",
+            "action": "store_true",
+            "default": false,
+            "help": "Perform pre-factory cleanup"
+          },
+          {
             "flag": "args",
             "default": [],
             "suppress_help": true,

--- a/csm/conf/cleanup.py
+++ b/csm/conf/cleanup.py
@@ -23,7 +23,7 @@ from csm.conf.setup import CsmSetupError, Setup
 
 class Cleanup(Setup):
     """
-    Delete all the CSM generated files and folders
+    Delete all the CSM generated files,folders, Configs and Non user collected data.
     """
 
     def __init__(self):
@@ -41,19 +41,43 @@ class Cleanup(Setup):
             Conf.load(const.DATABASE_INDEX, const.DATABASE_CONF_URL)
         except KvError as e:
             Log.error(f"Configuration Loading Failed {e}")
+        if command.options.get("pre-factory"):
+            # Pre-Factory: Cleanup system & take to pre-factory (Postinstall) stage
+            self._replace_csm_service_file()
+            self._service_user_cleanup()
         await self._unsupported_feature_entry_cleanup()
         self.files_directory_cleanup()
         self.web_env_file_cleanup()
         await self.cluster_admin_cleanup()
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
+    def _replace_csm_service_file(self):
+        '''
+        Service file cleanup
+        '''
+        Log.info(f"Replacing service file.")
+        Setup._run_cmd(f"cp -f {const.CSM_AGENT_SERVICE_FILE_SRC_PATH} /etc/systemd/system/")
+
+    def _service_user_cleanup(self):
+        '''
+        Remove service user if system deployed in dev mode.
+        '''
+        self._user = Conf.get(const.CSM_GLOBAL_INDEX, f"{const.CSM}>{const.USERNAME}")
+        if Conf.get(const.CSM_GLOBAL_INDEX, const.KEY_DEPLOYMENT_MODE) == const.DEV and \
+                    self._is_user_exist():
+            Log.info(f"Removing Service user: {self._user}")
+            Setup._run_cmd(f"userdel -f {self._user}")
+
     def files_directory_cleanup(self):
+        '''
+        Cleanup CSM config and Remove Log directory
+        '''
         files_directory_list = [
             const.RSYSLOG_PATH,
             const.CSM_LOGROTATE_DEST,
             const.DEST_CRON_PATH,
-            const.CSM_CONF_PATH,
-            Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path')
+            Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path'),
+            const.CSM_CONF_PATH
         ]
 
         for dir_path in files_directory_list:
@@ -61,12 +85,18 @@ class Cleanup(Setup):
             Setup._run_cmd(f"rm -rf {dir_path}")
 
     def web_env_file_cleanup(self):
-       Log.info(f"Replacing {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl " \
-                                    f"{const.CSM_WEB_DIST_ENV_FILE_PATH}")
-       Setup._run_cmd(f"cp -f {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl " \
+        '''
+        Web config (.env) Cleanup
+        '''
+        Log.info(f"Replacing {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl " \
+                                        f"{const.CSM_WEB_DIST_ENV_FILE_PATH}")
+        Setup._run_cmd(f"cp -f {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl " \
                                     f"{const.CSM_WEB_DIST_ENV_FILE_PATH}")
 
     async def _unsupported_feature_entry_cleanup(self):
+        '''
+        Remove CSM Unsupported features entries
+        '''
         Log.info("Unsupported feature cleanup")
         port = Conf.get(const.DATABASE_INDEX, 'databases>es_db>config>port')
         _es_db_url = (f"http://localhost:{port}/")

--- a/csm/conf/cleanup.py
+++ b/csm/conf/cleanup.py
@@ -41,7 +41,7 @@ class Cleanup(Setup):
             Conf.load(const.DATABASE_INDEX, const.DATABASE_CONF_URL)
         except KvError as e:
             Log.error(f"Configuration Loading Failed {e}")
-        if command.options.get("pre-factory"):
+        if command.options.get("pre_factory"):
             # Pre-Factory: Cleanup system & take to pre-factory (Postinstall) stage
             self._replace_csm_service_file()
             self._service_user_cleanup()

--- a/csm/conf/reset.py
+++ b/csm/conf/reset.py
@@ -29,7 +29,7 @@ from cortx.utils.data.db.consul_db.storage import CONSUL_ROOT
 
 class Reset(Setup):
     """
-    Reset csm Configuration.
+    Reset Csm User Data.
     """
     def __init__(self):
         super(Reset, self).__init__()
@@ -56,6 +56,9 @@ class Reset(Setup):
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
     def disable_and_stop_service(self):
+        '''
+        Stop and Disable CSM services
+        '''
         for each_service in [const.CSM_AGENT_SERVICE, const.CSM_WEB_SERVICE]:
             try:
                 service_obj = Service(each_service)
@@ -78,6 +81,9 @@ class Reset(Setup):
                 Log.warn(f"{each_service} not available: {e}")
 
     def directory_cleanup(self):
+        '''
+        Remove CSM Data directories
+        '''
         Log.info("Deleting files and folders")
 
         files_directory_list = [
@@ -90,20 +96,27 @@ class Reset(Setup):
             Setup._run_cmd(f"rm -rf {_path}")
 
     def reset_logs(self):
+        '''
+        Reset CSM logs. Removal will be part of Cleanup
+        '''
         Log.info("Reseting log files")
         log_dir = Conf.get(const.CSM_GLOBAL_INDEX, 'Log>log_path')
         csm_log_files = ["csm_agent.log", "csm_middleware.log", "cortxcli.log"]
         all_log_files = os.listdir(log_dir)
         for each_file in all_log_files:
             if each_file in csm_log_files:
+                # Reseting current log files
                 _file = os.path.join(log_dir, each_file)
                 Setup._run_cmd(f"truncate -s 0 {_file}")
             else:
+                # Remove other files.i.e. older log tar.gz files etc
                 _file = os.path.join(log_dir, each_file)
                 Setup._run_cmd(f"rm -rf {each_file}")
 
     async def db_cleanup(self):
-
+        '''
+        Remove User created ES and Consul data
+        '''
         port = Conf.get(const.DATABASE_INDEX, 'databases>es_db>config>port')
         self._es_db_url = (f"http://localhost:{port}/")
         port = Conf.get(const.DATABASE_INDEX, 'databases>consul_db>config>port')

--- a/csm/conf/setup.yaml
+++ b/csm/conf/setup.yaml
@@ -38,7 +38,7 @@ csm:
 
     cleanup:
         cmd: /opt/seagate/cortx/csm/bin/csm_setup cleanup
-        args: --config $URL
+        args: --config $URL [--pre-factory]
 
     reset:
         cmd: /opt/seagate/cortx/csm/bin/csm_setup reset

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -144,6 +144,7 @@ DATABASE_CONF_URL = f"yaml://{DATABASE_CONF}"
 DATABASE_CLI_CONF = '/etc/cli/database_cli.yaml'
 CSM_AGENT_SERVICE = "csm_agent.service"
 CSM_AGENT_SERVICE_FILE_PATH = f"/etc/systemd/system/{CSM_AGENT_SERVICE}"
+CSM_AGENT_SERVICE_FILE_SRC_PATH = f"{CSM_PATH}/conf/service/{CSM_AGENT_SERVICE}"
 CSM_WEB_SERVICE = "csm_web.service"
 CSM_WEB_SERVICE_FILE_PATH = f"/etc/systemd/system/{CSM_WEB_SERVICE}"
 CSM_WEB_ENV_FILE_PATH = f"{BASE_DIR}/csm/web/.env"


### PR DESCRIPTION
Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

# Backend

# Problem Statement
https://jts.seagate.com/browse/EOS-22899

Create Pre-factory interfacr in Cleanup phase for  csm-setup

## Design
- Pre-factory flag to be added to Cleanup phase
- Pre-factory will take system back to pre-factory stage i,e. Before post-install phase
- For csm_setup, prefactory will 
                   -- cleanup the service file
                   -- Remove service user in Dev mode only.
- Other functionalities of cleanup will run as it is
## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_Y
- _Confirm All CODACY errors are resolved. Yes/No?_Y

## Testing
Add Pre-factory arg to cleanup command
```
[root@ssc-vm-rhev4-0906 731368]# csm_setup cleanup --help
usage: csm_setup cleanup [-h] [--config CONFIG_URL] [--pre-factory]

optional arguments:
  -h, --help           show this help message and exit
  --config CONFIG_URL  Config Store URL e.g <type>://<path>.
  --pre-factory        Perform pre-factory cleanup
[root@ssc-vm-rhev4-0906 731368]#

```
Testing miniprovisioning steps
```
[root@ssc-vm-rhev4-0906 731368]# csm_setup post_install --config json:///opt/seagate/cortx_configs/provisioner_cluster.json && \
csm_setup prepare --config json:///opt/seagate/cortx_configs/provisioner_cluster.json && \
csm_setup config --config json:///opt/seagate/cortx_configs/provisioner_cluster.json && \
csm_setup init --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS
:PASS
:PASS
:PASS

[root@ssc-vm-rhev4-0906 731368]# cat /etc/group  | grep cortxub
wheel:x:10:centos,cortxub
haclient:x:189:hacluster,cortxub
cortxub:x:5007:

[root@ssc-vm-rhev4-0906 731368]# cat /etc/systemd/system/csm_agent.service
# CORTX-CSM: CORTX Management web and CLI interface.
# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
# This program is free software: you can redistribute it and/or modify
# it under the terms of the GNU Affero General Public License as published
# by the Free Software Foundation, either version 3 of the License, or
# (at your option) any later version.
# This program is distributed in the hope that it will be useful,
# but WITHOUT ANY WARRANTY; without even the implied warranty of
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
# GNU Affero General Public License for more details.
# You should have received a copy of the GNU Affero General Public License
# along with this program. If not, see <https://www.gnu.org/licenses/>.
# For any questions about this software or licensing,
# please email opensource@seagate.com or cortx-questions@seagate.com.

[Install]
WantedBy=multi-user.target

[Unit]
Description=Cloud Storage Manager
# Wants=rabbitmq-server.service
# After=rabbitmq-server.service syslog.target
# Requires=rabbitmq-server.service

[Service]
Type=forking
PermissionsStartOnly=true
#ExecStartPre=
ExecStartPre=/usr/bin/mkdir -p /var/run/csm
ExecStartPre=/usr/bin/touch /var/run/csm/csm_agent.pid
ExecStartPre=/usr/bin/chown cortxub:cortxub /var/run/csm/csm_agent.pid
ExecStart=/usr/bin/csm_agent
#ExecStopPost=/sbin/fuser -k 28101/tcp
ExecStopPost=/usr/bin/rm -rf /var/run/csm/csm_agent.pid
PIDFile=/var/run/csm/csm_agent.pid
User=cortxub
# Auto restart option is enabled depending on the system installation type.
#< RESTART_OPTION >
TimeoutStartSec=300
[root@ssc-vm-rhev4-0906 731368]#

[root@ssc-vm-rhev4-0906 731368]# pcs resource disable csm-web && pcs resource disable csm-agent

[root@ssc-vm-rhev4-0906 731368]# csm_setup reset --config json:///opt/seagate/cortx_configs/provisioner_cluster.json
:PASS

[root@ssc-vm-rhev4-0906 731368]# csm_setup cleanup --config json:///opt/seagate/cortx_configs/provisioner_cluster.json --pre-factory
:PASS
```
Cortxub user removed from system--> Only in DEV mode
```
[root@ssc-vm-rhev4-0906 731368]# cat /etc/group  | grep cortxub
[root@ssc-vm-rhev4-0906 731368]#

```
csm_agent.service file cleanup
```
[root@ssc-vm-rhev4-0906 731368]# cat /etc/systemd/system/csm_agent.service
# CORTX-CSM: CORTX Management web and CLI interface.
# Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
# This program is free software: you can redistribute it and/or modify
# it under the terms of the GNU Affero General Public License as published
# by the Free Software Foundation, either version 3 of the License, or
# (at your option) any later version.
# This program is distributed in the hope that it will be useful,
# but WITHOUT ANY WARRANTY; without even the implied warranty of
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
# GNU Affero General Public License for more details.
# You should have received a copy of the GNU Affero General Public License
# along with this program. If not, see <https://www.gnu.org/licenses/>.
# For any questions about this software or licensing,
# please email opensource@seagate.com or cortx-questions@seagate.com.

[Install]
WantedBy=multi-user.target

[Unit]
Description=Cloud Storage Manager
# Wants=rabbitmq-server.service
# After=rabbitmq-server.service syslog.target
# Requires=rabbitmq-server.service

[Service]
Type=forking
PermissionsStartOnly=true
#ExecStartPre=
ExecStartPre=/usr/bin/mkdir -p /var/run/csm
ExecStartPre=/usr/bin/touch /var/run/csm/csm_agent.pid
ExecStartPre=/usr/bin/chown <USER>:<USER> /var/run/csm/csm_agent.pid
ExecStart=/usr/bin/csm_agent
#ExecStopPost=/sbin/fuser -k 28101/tcp
ExecStopPost=/usr/bin/rm -rf /var/run/csm/csm_agent.pid
PIDFile=/var/run/csm/csm_agent.pid
User=<USER>
# Auto restart option is enabled depending on the system installation type.
#< RESTART_OPTION >
TimeoutStartSec=300


```
- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_
- _Confirm Testing was performed with installed RPM. Yes/No?_
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_

## Checklist

- _PR is self-reviewed? Yes/No?_
- _GitHub Issue is updated_
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._
        -  _Verification needs to be done before marked as Closed/Verified_
        - _Any interface change Yes/No?_
        - _Change notified to other gatekeepers: Yes/No?_
        - _Code reviews done and addressed: Yes/No?_
        - _Codacy issues reviewed and addressed: Yes/No?_
        - _Deployment test : Done/Not?_
        - _UT/smoke test: Done/Not?_
        - _Jira number added to PR: Yes/No?_
        - _Github merge done using UI: Yes/No?_
        - _Side effects on other features - deployment/update/node-replacement_
        - _Changes to quick-start-guide/community impact_
        - _All dependent component code PR are raised or already merged Yes/No_
        - _All dependent code already merged in landing branch Yes/No_
