### PR TITLE
EOS-24887: cortxcli support_bundle CLI should invoke utils code.

### DIFF
--- a/csm/cli/schema/support_bundle.json
+++ b/csm/cli/schema/support_bundle.json
@@ -34,11 +34,11 @@
             "provisioner",
             "os",
             "health_map",
-            "manifest",
             "alerts",
             "uds",
             "elasticsearch",
-            "ha"
+            "ha",
+            "utils"
           ],
           "nargs": "+",
           "help": "Generate Bundle for Specific components defined."
@@ -53,8 +53,8 @@
       ],
       "comm": {
         "type": "direct",
-        "target": "csm.cli.support_bundle",
-        "method": "bundle_generate",
+        "target": "cortx.utils.support_framework",
+        "method": "_generate_bundle",
         "class": "SupportBundle",
         "is_static": true
       }
@@ -92,8 +92,8 @@
       ],
       "comm": {
         "type": "direct",
-        "target": "csm.cli.support_bundle",
-        "method": "bundle_status",
+        "target": "cortx.utils.support_framework",
+        "method": "_get_bundle_status",
         "class": "SupportBundle",
         "is_static": true
       },


### PR DESCRIPTION
Signed-off-by: Parayya Vastrad <parayya.vastrad@seagate.com>

# Backend

# Problem Statement
- cortxcli support_bundle CLI should invoke utils code

- _Overview: JIRA number/GitHub Issue added to PR: [Y/N]:_ Y
-  https://jts.seagate.com/browse/EOS-24887
- _Describe the problem this patch intends to solve._ Currently Cortxcli support_bundle code pointing to CSM, should be redirected to utils code

## Design

- _For Bug describe the fix here._ NA
- _For feature, post the link to the solution page._
- _Any northbound interface change and has been notified to other gatekeepers [Y/N]:_ N


## Coding

- _Coding conventions are followed and code is consistent. Yes/No?_ Yes
- _Confirm All CODACY errors are resolved. Yes/No?_ Yes

## Testing

- _Confirm that Test Cases are added (for both the cases, fix and feature). Yes/No?_ NA
- _Confirm Test Cases cover Happy Path, Non-Happy Path and Scalability. Yes/No?_ NA
- _Confirm Testing was performed with installed RPM. Yes/No?_ Yes
- _Confirm all the ut/regression/smoke test has been performed [Y/N]_ NA

## Checklist

- _PR is self-reviewed? Yes/No?_ Yes
- _GitHub Issue is updated_ NA
- _Jira is updated_
  -  _Check if the description is clear and explained._ 
    -  _Check Acceptance Criterion is defined._
      -  _All the tests performed should be mentioned before Resolving a JIRA._ NA
        -  _Verification needs to be done before marked as Closed/Verified_ 
        - _Any interface change Yes/No?_ No
        - _Change notified to other gatekeepers: Yes/No?_ NA
        - _Code reviews done and addressed: Yes/No?_ Yes
        - _Codacy issues reviewed and addressed: Yes/No?_ Yes
        - _Deployment test : Done/Not?_ Yes
        - _UT/smoke test: Done/Not?_ NA
        - _Jira number added to PR: Yes/No?_ Yes
        - _Github merge done using UI: Yes/No?_ NA
        - _Side effects on other features - deployment/update/node-replacement_ NA
        - _Changes to quick-start-guide/community impact_ NA
        - _All dependent component code PR are raised or already merged Yes/No_ NA
        - _All dependent code already merged in landing branch Yes/No_ NA

```
[root@ssc-vm-g3-rhev4-0695 cortx-utils]# cortxcli support_bundle generate 'test all'
Please use the below bundle id for checking the status of support bundle.
--------------
| SBv0rv3n54 |
--------------
Please Find the file on -> /var/log/cortx/support_bundle/ .
[root@ssc-vm-g3-rhev4-0695 cortx-utils]# cortxcli support_bundle status SBv0rv3n54
+------------+----------+---------------------------------------+-----------------------------------------------------------------+---------+
| Bundle Id  | Comment  |               Node Name               |                             Message                             |  Result |
+------------+----------+---------------------------------------+-----------------------------------------------------------------+---------+
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com | '/opt/seagate/health_view/conf/setup.yaml' file does not exist! |  Error  |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |         Bundle generation started for component - 'csm'         | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |         Bundle generation started for component - 'sspl'        | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |       Bundle generation started for component - 's3server'      | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |         Bundle generation started for component - 'motr'        | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |         Bundle generation started for component - 'hare'        | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |     Bundle generation started for component - 'provisioner'     | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |        Bundle generation started for component - 'alerts'       | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |         Bundle generation started for component - 'uds'         | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |    Bundle generation started for component - 'elasticsearch'    | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |          Bundle generation started for component - 'ha'         | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |        Bundle generation started for component - 'utils'        | Success |
| SBv0rv3n54 | test all | ssc-vm-g3-rhev4-0695.colo.seagate.com |               Support bundle generation completed.              | Success |
+------------+----------+---------------------------------------+-----------------------------------------------------------------+---------+
```
