### PR TITLE
EOS-25510: Unable to communicate with s3 on https with self-signed certificate

### DIFF
--- a/csm/core/services/s3/utils.py
+++ b/csm/core/services/s3/utils.py
@@ -42,6 +42,8 @@ class CsmS3ConfigurationFactory:
             const.CSM_GLOBAL_INDEX, const.IAM_PORT)
         iam_connection_config.max_retries_num = Conf.get(const.CSM_GLOBAL_INDEX,
                                                          const.S3_MAX_RETRIES_NUM)
+        if Conf.get(const.CSM_GLOBAL_INDEX, const.IAM_PROTOCOL) == 'https':
+            iam_connection_config.use_ssl = True
         return iam_connection_config
 
     @staticmethod
@@ -57,6 +59,8 @@ class CsmS3ConfigurationFactory:
             const.CSM_GLOBAL_INDEX, const.S3_DATA_PORT)
         s3_connection_config.max_retries_num = Conf.get(const.CSM_GLOBAL_INDEX,
                                                         const.S3_MAX_RETRIES_NUM)
+        if Conf.get(const.CSM_GLOBAL_INDEX, const.S3_DATA_PROTOCOL) == 'https':
+            s3_connection_config.use_ssl = True
         return s3_connection_config
 
 


### PR DESCRIPTION
Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

# Problem Statement
https://jts.seagate.com/browse/EOS-25510
Unable to communicate with s3 on https with self-signed certificate

# Design
Csm code not checking ssl-context
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
![image](https://user-images.githubusercontent.com/66424882/137934523-06017c3f-680e-401c-8ea1-bd637c6f6cd7.png)

  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
