### PR TITLE
EOS-25545: Fix invalid model field in the password check

### DIFF
--- a/csm/core/services/sessions.py
+++ b/csm/core/services/sessions.py
@@ -177,7 +177,7 @@ class LocalAuthPolicy(AuthPolicy):
     """ Local CSM user authentication policy """
 
     async def authenticate(self, user: User, password: str) -> Optional[SessionCredentials]:
-        if Passwd.verify(password, user.password_hash):
+        if Passwd.verify(password, user.user_password):
             return LocalCredentials(user.user_id, user.role)
         return None
 


### PR DESCRIPTION
Replace password_hash with user_password.

# Problem Statement
- [EOS-25545](https://jts.seagate.com/browse/EOS-25545): K8-RC3: CSM REST login failed with AttributeError

# Design
-  It looks like, the password verification code referred to the model's field still actual in 'main', but outdated in 'kubernetes'. Changed the field name.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
