### PR TITLE
EOS-25566: fix the invalid field name in authentication

### DIFF
--- a/csm/core/services/sessions.py
+++ b/csm/core/services/sessions.py
@@ -178,7 +178,7 @@ class LocalAuthPolicy(AuthPolicy):
 
     async def authenticate(self, user: User, password: str) -> Optional[SessionCredentials]:
         if Passwd.verify(password, user.user_password):
-            return LocalCredentials(user.user_id, user.role)
+            return LocalCredentials(user.user_id, user.user_role)
         return None
 
 


### PR DESCRIPTION
# Problem Statement
- [EOS-25566](https://jts.seagate.com/browse/EOS-25566): CSM REST login failed with Attribute Error, object has no attribute 'role'

# Design
-  Replace user.role with user.user_role

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
