### PR TITLE
EOS-25584: K8-RC3: CSM REST login response is 500 in case of invalid / incorrect username/password

### DIFF
--- a/csm/core/services/sessions.py
+++ b/csm/core/services/sessions.py
@@ -200,6 +200,8 @@ class S3AuthPolicy(AuthPolicy):
         cfg.host = Conf.get(const.CSM_GLOBAL_INDEX, const.IAM_HOST)
         cfg.port = Conf.get(const.CSM_GLOBAL_INDEX, const.IAM_PORT)
         cfg.max_retries_num = Conf.get(const.CSM_GLOBAL_INDEX, 'S3>max_retries_num')
+        if Conf.get(const.CSM_GLOBAL_INDEX, const.IAM_PROTOCOL) == 'https':
+            cfg.use_ssl = True
 
         Log.debug(f'Authenticating {user.user_id}'
                   f' with S3 IAM server {cfg.host}:{cfg.port}')


### PR DESCRIPTION
# Problem Statement
- https://jts.seagate.com/browse/EOS-25584

# Design
Check for protocol as https then use ssl context

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
```
[root@ssc-vm-g3-rhev4-1992 ~]# curl --location --request POST 'https://172.18.146.80:8081/api/v2/login?debug' --header 'lication/json' -d '{"username": "cortxadmin","password": "Cortxadmin@1233"}' -k
401: Unauthorized
```
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
