### PR TITLE
EOS-25584: Raise 503 instead of 500 for s3 operations

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -423,8 +423,6 @@ class CsmRestApi(CsmApi, ABC):
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=500)
         except CsmNotImplemented as e:
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=501)
-        except ServerDisconnectedError as e:
-            return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=503)
         except CsmGatewayTimeout as e:
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=504)
         except CsmServiceConflict as e:
@@ -435,6 +433,8 @@ class CsmRestApi(CsmApi, ABC):
             Log.error(f"Error: {e} \n {traceback.format_exc()}")
             message = f"Missing Key for {e}"
             return CsmRestApi.json_response(CsmRestApi.error_response(KeyError(message), request = request, request_id = request_id), status=422)
+        except ServerDisconnectedError as e:
+            return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=503)
         except Exception as e:
             Log.critical(f"Unhandled Exception Caught: {e} \n {traceback.format_exc()}")
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=500)


### PR DESCRIPTION
Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

# Problem Statement
Implemetating as per comment https://jts.seagate.com/browse/EOS-25584?focusedCommentId=2224282&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2224282

# Design
Except ServerDisconnectError and riase as 503 error code

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
```
[root@ssc-vm-g3-rhev4-1992 ~]# curl -L -X POST 'https://172.18.146.80:8082/api/v2/s3_accounts' -H 'Authorization: Bearer e1b333148e4b4520ae8747dad1342c4c' -H 'Content-Type: application/json' -d '{
"account_name":"s3_udayan_01",
"account_email": "s3_udayan_01@gmail.com",
"password":"Seagate@123"
}' -k -v
* About to connect() to 172.18.146.80 port 8082 (#0)
*   Trying 172.18.146.80...
* Connected to 172.18.146.80 (172.18.146.80) port 8082 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
* skipping SSL peer certificate verification
* SSL connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate:
*       subject: CN=seagate.com,O=Seagate Tech,L=Pune,C=IN
*       start date: Feb 18 11:58:25 2021 GMT
*       expire date: Feb 16 11:58:25 2031 GMT
*       common name: seagate.com
*       issuer: CN=seagate.com,O=Seagate Tech,L=Pune,C=IN
> POST /api/v2/s3_accounts HTTP/1.1
> User-Agent: curl/7.29.0
> Host: 172.18.146.80:8082
> Accept: */*
> Authorization: Bearer e1b333148e4b4520ae8747dad1342c4c
> Content-Type: application/json
> Content-Length: 102
>
* upload completely sent off: 102 out of 102 bytes
< HTTP/1.1 503 Service Unavailable
< Content-Type: application/json; charset=utf-8
< Strict-Transport-Security: max-age=63072000; includeSubdomains
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< Content-Security-Policy: script-src 'self'; object-src 'self'
< Referrer-Policy: no-referrer, strict-origin-when-cross-origin
< Pragma: no-cache
< Expires: 0
< Cache-control: no-cache, no-store, must-revalidate, max-age=0
< Content-Length: 39
< Date: Tue, 26 Oct 2021 08:31:18 GMT
< Server: Python/3.6 aiohttp/3.6.1
<
* Connection #0 to host 172.18.146.80 left intact
{"error_code": null, "message": "None"}

```
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
