### PR TITLE
EOS-25529: POC for CSM Audit logs

### DIFF
--- a/experiments/audit_logs/audit_logs.py
+++ b/experiments/audit_logs/audit_logs.py
@@ -1,0 +1,66 @@
+#!/bin/python3
+
+# CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+from datetime import datetime
+from experiments.audit_logs.log_store_collection import LogStoreFactory
+
+class AuditLogStore():
+    '''
+    Base class for Auditlog store
+    '''
+
+    def __init__(self, storage_url, component='audit'):
+        self.storage_url = storage_url
+        self.component = component
+        self._log_store_instance = LogStoreFactory.get_instance(storage_url)
+
+    @staticmethod
+    def store():
+        raise NotImplementedError
+
+    @staticmethod
+    def search():
+        raise NotImplementedError
+
+class CsmAuditLogStore(AuditLogStore):
+    def __init__(self, storage_url, component='CSM'):
+        super(CsmAuditLogStore,self).__init__(storage_url,component)
+
+    def store(self, *args, **kwargs):
+        '''
+        Store auditlog
+        '''
+        kwargs["timestamp"] = str(datetime.now())
+        kwargs["component"] = self.component
+        self._log_store_instance.store(kwargs)
+
+    def search(self):
+        '''
+        Fetch auditlog
+        '''
+        data = self._log_store_instance.search(self.component)
+        print(data)
+
+# Test File storage for audit logs
+file_auditlog_example = CsmAuditLogStore('file:///tmp/auditlog.log')
+file_auditlog_example.store(user="admin", remote_ip="127.0.0.1",method="POST",path="/api/v2/login")
+file_auditlog_example.search()
+
+# Test Consul storage for audit logs
+consul_auditlog_example = CsmAuditLogStore('consul:///')
+consul_auditlog_example.store(user="admin", remote_ip="127.0.0.1",method="POST",path="/api/v2/login")
+consul_auditlog_example.search()

--- a/experiments/audit_logs/log_store_collection.py
+++ b/experiments/audit_logs/log_store_collection.py
@@ -1,0 +1,104 @@
+#!/bin/python3
+
+# CORTX Python common library.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+
+from urllib.parse import urlparse
+import inspect, os, sys
+from consul import Consul
+
+from cortx.utils.kv_store.kv_store import KvStore as BaseStore
+from cortx.utils.kv_store.kv_store_collection import ConsulKvPayload
+
+class FileStore(BaseStore):
+    _identifier = 'file'
+    def __init__(self, store_loc, store_path, delim='>'):
+        super(FileStore, self).__init__(store_loc, store_path, delim)
+        if not os.path.exists(self._store_path):
+            with open(self._store_path, 'w+') as f:
+                pass
+
+    def store(self, data):
+        '''
+        Store data to File
+        '''
+        s1 = f"{data['timestamp']} {data['component']} {data['user']} {data['remote_ip']} {data['path']}"
+        with open(self._store_path, 'a') as f:
+            f.write(str(s1))
+            f.write("\n")
+
+    def search(self, filter):
+        '''
+        Search data from File
+        '''
+        with open(self._store_path) as f:
+            data = f.read()
+        return data
+
+class ConsulStore(BaseStore):
+    _identifier = 'consul'
+    def __init__(self, store_loc, store_path, delim='>'):
+        super(ConsulStore,self).__init__(store_loc, store_path, delim)
+        if store_loc:
+            if ':' in store_loc:
+                host, port = store_loc.split(':')
+            else:
+                host, port = store_loc, 8500
+        else:
+            host, port = '127.0.0.1', 8500
+        self.c = Consul(host=host, port=port)
+        self._payload = ConsulKvPayload(self.c, self._delim)
+        self._consul_base = 'cortx/logs/auditlog/'
+
+    def store(self,data):
+        '''
+        Store data to Consul
+        '''
+        self._payload._set(f"{self._consul_base}{data['component']}/{data['timestamp']}", str(data))
+
+    def search(self, component):
+        '''
+        Search data from Consul
+        '''
+        data = self._payload.get_keys(self._consul_base+component)
+        if data:
+            return {each_data:self._payload.get(each_data) for each_data in data}
+
+class LogStoreFactory:
+    _stores = {}
+
+    def __init__(self):
+        """ Initializing LogStoreFactory """
+        pass
+
+    @staticmethod
+    def get_instance(store_url: str, delim='>'):
+        """ Obtain instance of KvStore for given file_type """
+
+        url_spec = urlparse(store_url)
+        store_type = url_spec.scheme
+        store_loc = url_spec.netloc
+        store_path = url_spec.path
+
+        if store_url in LogStoreFactory._stores.keys():
+            return LogStoreFactory._stores[store_url]
+
+        storage = inspect.getmembers(sys.modules[__name__],inspect.isclass)
+        for name, cls in storage:
+            if hasattr(cls, '_identifier') and store_type == cls._identifier:
+                LogStoreFactory._stores[store_url] = cls(store_loc, store_path,
+                                                        delim)
+                return LogStoreFactory._stores[store_url]

--- a/experiments/audit_logs/log_store_collection.py
+++ b/experiments/audit_logs/log_store_collection.py
@@ -25,8 +25,8 @@ from cortx.utils.kv_store.kv_store_collection import ConsulKvPayload
 
 class FileStore(BaseStore):
     _identifier = 'file'
-    def __init__(self, store_loc, store_path, delim='>'):
-        super(FileStore, self).__init__(store_loc, store_path, delim)
+    def __init__(self, store_loc, store_path):
+        super(FileStore, self).__init__(store_loc, store_path)
         if not os.path.exists(self._store_path):
             with open(self._store_path, 'w+') as f:
                 pass
@@ -40,7 +40,7 @@ class FileStore(BaseStore):
             f.write(str(s1))
             f.write("\n")
 
-    def search(self, filter):
+    def search(self, search_filter):
         '''
         Search data from File
         '''
@@ -50,8 +50,8 @@ class FileStore(BaseStore):
 
 class ConsulStore(BaseStore):
     _identifier = 'consul'
-    def __init__(self, store_loc, store_path, delim='>'):
-        super(ConsulStore,self).__init__(store_loc, store_path, delim)
+    def __init__(self, store_loc, store_path):
+        super(ConsulStore,self).__init__(store_loc, store_path)
         if store_loc:
             if ':' in store_loc:
                 host, port = store_loc.split(':')
@@ -82,10 +82,9 @@ class LogStoreFactory:
 
     def __init__(self):
         """ Initializing LogStoreFactory """
-        pass
 
     @staticmethod
-    def get_instance(store_url: str, delim='>'):
+    def get_instance(store_url: str):
         """ Obtain instance of KvStore for given file_type """
 
         url_spec = urlparse(store_url)
@@ -99,6 +98,5 @@ class LogStoreFactory:
         storage = inspect.getmembers(sys.modules[__name__],inspect.isclass)
         for name, cls in storage:
             if hasattr(cls, '_identifier') and store_type == cls._identifier:
-                LogStoreFactory._stores[store_url] = cls(store_loc, store_path,
-                                                        delim)
+                LogStoreFactory._stores[store_url] = cls(store_loc, store_path)
                 return LogStoreFactory._stores[store_url]


### PR DESCRIPTION
Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

# Problem Statement
https://jts.seagate.com/browse/EOS-25529
POC for Audit log storage 

# Design
Idea is to provide support to audit logs when Elastic search is not available in LC
POC for audit log storage in File and Consul storage.
Adaptor pattern is used which is similar to KV store which is already utilized in Py-Utils

https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/770670731/POC+-+CSM+Audit+Logs

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
