### PR TITLE
EOS-25584: Raise 503 instead of 500 for s3 operations

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -423,8 +423,6 @@ class CsmRestApi(CsmApi, ABC):
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=500)
         except CsmNotImplemented as e:
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=501)
-        except ServerDisconnectedError as e:
-            return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=503)
         except CsmGatewayTimeout as e:
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=504)
         except CsmServiceConflict as e:
@@ -435,6 +433,8 @@ class CsmRestApi(CsmApi, ABC):
             Log.error(f"Error: {e} \n {traceback.format_exc()}")
             message = f"Missing Key for {e}"
             return CsmRestApi.json_response(CsmRestApi.error_response(KeyError(message), request = request, request_id = request_id), status=422)
+        except ServerDisconnectedError as e:
+            return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=503)
         except Exception as e:
             Log.critical(f"Unhandled Exception Caught: {e} \n {traceback.format_exc()}")
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=500)

--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -26,6 +26,7 @@ from concurrent.futures import CancelledError as ConcurrentCancelledError
 from asyncio import CancelledError as AsyncioCancelledError
 from weakref import WeakSet
 from aiohttp import web, web_exceptions
+from aiohttp.client_exceptions import ServerDisconnectedError
 from abc import ABC
 from ipaddress import ip_address
 from secure import SecureHeaders
@@ -422,6 +423,8 @@ class CsmRestApi(CsmApi, ABC):
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=500)
         except CsmNotImplemented as e:
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=501)
+        except ServerDisconnectedError as e:
+            return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=503)
         except CsmGatewayTimeout as e:
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=504)
         except CsmServiceConflict as e:

--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -26,7 +26,7 @@ from concurrent.futures import CancelledError as ConcurrentCancelledError, Timeo
 from asyncio import CancelledError as AsyncioCancelledError
 from weakref import WeakSet
 from aiohttp import web, web_exceptions
-from aiohttp.client_exceptions import ServerDisconnectedError, ClientConnectorError
+from aiohttp.client_exceptions import ServerDisconnectedError, ClientConnectorError, ClientOSError
 from abc import ABC
 from ipaddress import ip_address
 from secure import SecureHeaders
@@ -433,7 +433,7 @@ class CsmRestApi(CsmApi, ABC):
             Log.error(f"Error: {e} \n {traceback.format_exc()}")
             message = f"Missing Key for {e}"
             return CsmRestApi.json_response(CsmRestApi.error_response(KeyError(message), request = request, request_id = request_id), status=422)
-        except (ServerDisconnectedError, ClientConnectorError, ConcurrentTimeoutError) as e:
+        except (ServerDisconnectedError, ClientConnectorError, ClientOSError, ConcurrentTimeoutError) as e:
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=503)
         except Exception as e:
             Log.critical(f"Unhandled Exception Caught: {e} \n {traceback.format_exc()}")

--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -22,11 +22,11 @@ import traceback
 import signal
 import ssl
 import time
-from concurrent.futures import CancelledError as ConcurrentCancelledError
+from concurrent.futures import CancelledError as ConcurrentCancelledError, TimeoutError as ConcurrentTimeoutError
 from asyncio import CancelledError as AsyncioCancelledError
 from weakref import WeakSet
 from aiohttp import web, web_exceptions
-from aiohttp.client_exceptions import ServerDisconnectedError
+from aiohttp.client_exceptions import ServerDisconnectedError, ClientConnectorError
 from abc import ABC
 from ipaddress import ip_address
 from secure import SecureHeaders
@@ -433,7 +433,7 @@ class CsmRestApi(CsmApi, ABC):
             Log.error(f"Error: {e} \n {traceback.format_exc()}")
             message = f"Missing Key for {e}"
             return CsmRestApi.json_response(CsmRestApi.error_response(KeyError(message), request = request, request_id = request_id), status=422)
-        except ServerDisconnectedError as e:
+        except (ServerDisconnectedError, ClientConnectorError, ConcurrentTimeoutError) as e:
             return CsmRestApi.json_response(CsmRestApi.error_response(e, request = request, request_id = request_id), status=503)
         except Exception as e:
             Log.critical(f"Unhandled Exception Caught: {e} \n {traceback.format_exc()}")


### PR DESCRIPTION
# Problem Statement
Handle  error 500 raised deu to s3 problem

# Design
Handle ClientConnectionError and Timeout Error and raise as 503 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
Handling 503 incase of
1. Incorrect PORT number, which throwa TimeoutError
![image](https://user-images.githubusercontent.com/66424882/140718187-4530a464-ee3e-48b7-abc9-9243cebd374c.png)

2. Incorrect HOST, which throws ClientConnectionError

![image](https://user-images.githubusercontent.com/66424882/140718666-305f4aff-3cfa-484c-b5e1-7c1c7a712c72.png)

  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
