### PR TITLE
EOS-26712: Expose Upgrade interface for csm_setup

### DIFF
--- a/csm/cli/schema/csm_setup.json
+++ b/csm/cli/schema/csm_setup.json
@@ -304,6 +304,41 @@
       }
     },
     {
+      "name": "upgrade",
+      "description": "Perform upgrade opertions for csm",
+      "need_confirmation": false,
+      "permissions_tag": "update",
+      "args": [
+        {
+          "flag": "--config",
+          "dest": "config_url",
+          "type": "str",
+          "required": true,
+          "help": "Config Store URL e.g <type>://<path>."
+        },
+        {
+            "flag": "--services",
+            "help": "Run csm-service miniprovisioning",
+            "default": "all",
+            "type": "str",
+            "nargs": "?"
+        },
+        {
+          "flag": "args",
+          "default": [],
+          "suppress_help": true,
+          "nargs": "?"
+        }
+      ],
+      "comm": {
+        "type": "direct",
+        "target": "csm.conf.upgrade",
+        "method": "execute",
+        "class": "Upgrade",
+        "is_static": false
+      }
+    },
+    {
       "name": "post_upgrade",
       "description": "Perform post_upgrade for csm",
       "need_confirmation": false,

--- a/csm/conf/csm_setup.py
+++ b/csm/conf/csm_setup.py
@@ -81,6 +81,7 @@ if __name__ == '__main__':
     from csm.conf.init import Init
     from csm.conf.reset import Reset
     from csm.conf.test import Test
+    from csm.conf.upgrade import Upgrade
     from csm.conf.pre_upgrade import PreUpgrade
     from csm.conf.post_upgrade import PostUpgrade
     from csm.conf.cleanup import Cleanup

--- a/csm/conf/setup.yaml
+++ b/csm/conf/setup.yaml
@@ -45,6 +45,8 @@ csm:
         args: --config $URL [--services $service_name]
 
     upgrade:
+          cmd: /opt/seagate/cortx/csm/bin/csm_setup upgrade
+          args: --config $URL [--services $service_name]
       pre:
           cmd: /opt/seagate/cortx/csm/bin/csm_setup pre_upgrade
           args: --config $URL [--services $service_name]

--- a/csm/conf/upgrade.py
+++ b/csm/conf/upgrade.py
@@ -1,0 +1,32 @@
+# CORTX-CSM: CORTX Management web and CLI interface.
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+
+from csm.core.providers.providers import Response
+from csm.core.blogic import const
+from csm.common.errors import CSM_OPERATION_SUCESSFUL
+from cortx.utils.log import Log
+from csm.conf.setup import Setup
+
+class Upgrade(Setup):
+    """
+    Perform preinstall operations for csm
+    """
+    def __init__(self):
+        super(Upgrade, self).__init__()
+
+    async def execute(self, command):
+        Log.info("Perform upgrade for csm_setup")
+        # TODO: Implement upgrade logic
+        return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)

--- a/csm/conf/upgrade.py
+++ b/csm/conf/upgrade.py
@@ -21,7 +21,7 @@ from csm.conf.setup import Setup
 
 class Upgrade(Setup):
     """
-    Perform preinstall operations for csm
+    Perform upgrade operations for csm
     """
     def __init__(self):
         super(Upgrade, self).__init__()


### PR DESCRIPTION
# Problem Statement
- Expose Upgrade interface for csm_setup
- https://jts.seagate.com/browse/EOS-26712

# Design
Exposing Upgrade interface for csm-setup. No implemetetion for now

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
![image](https://user-images.githubusercontent.com/66424882/144280540-4a3a9e14-e32e-422f-8139-bd234dcfc5a9.png)

![image](https://user-images.githubusercontent.com/66424882/144280596-cc1c4e5b-d3da-42c2-b2c1-4036473de14f.png)

![image](https://user-images.githubusercontent.com/66424882/144280718-015b4e28-a13e-493f-b0b4-dc1cea06405c.png)

- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
