### PR TITLE
EOS-26603 : Wrong error code and message for while editing role of last admin user

### DIFF
--- a/csm/core/services/users.py
+++ b/csm/core/services/users.py
@@ -332,7 +332,7 @@ class CsmUserService(ApplicationService):
 
         password = new_values.get(const.PASS, None)
         current_password = new_values.get(const.CSM_USER_CURRENT_PASSWORD, None)
-        role = new_values.get('role', None)
+        role = new_values.get('user_role', None)
         reset_password = new_values.get('reset_password', None)
 
         allowed = CSM_USER_PASSWD_UPDATE_RULES[loggedin_user_role][user_role].apply(self_update)


### PR DESCRIPTION
Signed-off-by: Pranali04796 <pranali.ugale@seagate.com>

# Problem Statement
- [EOS: 26603](https://jts.seagate.com/browse/EOS-26603)
-  While editing role of last admin user it is throwing wrong error message.
# Design
-  User_role must be extract properly with correct name. 

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed on container.

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
![image](https://user-images.githubusercontent.com/68841079/145030408-d6f89f89-3172-42fa-8d3e-5289007dbd81.png)
