### PR TITLE
EOS-26124: Create S3Account failure fix

### DIFF
--- a/csm/core/services/s3/accounts.py
+++ b/csm/core/services/s3/accounts.py
@@ -13,6 +13,8 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
+import time
+
 from typing import Dict
 
 from csm.core.blogic import const
@@ -58,6 +60,9 @@ class S3AccountService(S3BaseService):
                                                                 access_key, secret_key)
         if isinstance(account, IamError):
             self._handle_error(account, args={'account_name': account_name})
+
+        # Adding wait for replication in ldap to complete
+        time.sleep(3)
 
         account_client = self._s3plugin.get_iam_client(account.access_key_id,
             account.secret_key_id, CsmS3ConfigurationFactory.get_iam_connection_config())


### PR DESCRIPTION
# Problem Statement
- CSM REST: Create S3 account failed with 500 ('InternalFailure' is not a valid IamErrors)

# Design
-  Added a wait of 3 seconds between create account and create login profile to let openldap replicate the data.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide

Signed-off-by: Shri Metta <shri.metta@seagate.com>