### PR TITLE
EOS-27191: Remove S3 user login through management API & Remove is_k8s check from miniprovisioing phases

### DIFF
--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -79,17 +79,11 @@ class Configure(Setup):
         if not "agent" in services:
             return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
         self._prepare_and_validate_confstore_keys()
-        if not Setup.is_k8s_env:
-            self._set_deployment_mode()
-            self._logrotate()
-            self._configure_cron()
-            self._configure_uds_keys()
-            self._configure_csm_web_keys()
-        else:
-            self.cluster_id = Conf.get(const.CONSUMER_INDEX,
-                            self.conf_store_keys[const.KEY_CLUSTER_ID])
-            self.set_csm_endpoint()
-            self.set_s3_info()
+
+        self.cluster_id = Conf.get(const.CONSUMER_INDEX,
+                        self.conf_store_keys[const.KEY_CLUSTER_ID])
+        self.set_csm_endpoint()
+        self.set_s3_info()
         try:
             self._configure_csm_ldap_schema()
             self._set_user_collection()
@@ -114,19 +108,7 @@ class Configure(Setup):
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
     def _prepare_and_validate_confstore_keys(self):
-        if not Setup.is_k8s_env:
-            self.conf_store_keys.update({
-                const.KEY_SERVER_NODE_INFO:f"{const.SERVER_NODE}>{self.machine_id}",
-                const.KEY_SERVER_NODE_TYPE:f"{const.SERVER_NODE}>{self.machine_id}>{const.TYPE}",
-                const.KEY_ENCLOSURE_ID:f"{const.SERVER_NODE}>{self.machine_id}>{const.STORAGE}>{const.ENCLOSURE_ID}",
-                const.KEY_DATA_NW_PUBLIC_FQDN:f"{const.SERVER_NODE}>{self.machine_id}>{const.NETWORK}>{const.DATA}>{const.PUBLIC_FQDN}",
-                const.KEY_CSM_USER:f"{const.CORTX}>{const.SOFTWARE}>{const.NON_ROOT_USER}>{const.USER}",
-                const.KEY_CLUSTER_ID:f"{const.SERVER_NODE}>{self.machine_id}>{const.CLUSTER_ID}",
-                const.KEY_ROOT_LDAP_USER:f"{const.CORTX}>{const.SOFTWARE}>{const.OPENLDAP}>{const.ROOT}>{const.USER}",
-                const.KEY_ROOT_LDAP_SECRET:f"{const.CORTX}>{const.SOFTWARE}>{const.OPENLDAP}>{const.ROOT}>{const.SECRET}"
-                })
-        else:
-            self.conf_store_keys.update({
+        self.conf_store_keys.update({
                 const.KEY_SERVER_NODE_INFO:f"{const.NODE}>{self.machine_id}",
                 const.KEY_SERVER_NODE_TYPE:f"{const.ENV_TYPE_KEY}",
                 const.KEY_CLUSTER_ID:f"{const.NODE}>{self.machine_id}>{const.CLUSTER_ID}",
@@ -191,88 +173,6 @@ class Configure(Setup):
         s3_auth_secret = Conf.get(const.CONSUMER_INDEX, const.S3_AUTH_SECRET_KEY)
         Conf.set(const.CSM_GLOBAL_INDEX, const.S3_AUTH_USER_CONF, s3_auth_user)
         Conf.set(const.CSM_GLOBAL_INDEX, const.S3_AUTH_SECRET_CONF, s3_auth_secret)
-
-    def _configure_cron(self):
-        """
-        Configure common rsyslog and logrotate
-        Also cleanup statsd
-        """
-        if os.path.exists(const.CRON_DIR):
-            Setup._run_cmd(f"cp -f {const.SOURCE_CRON_PATH} {const.DEST_CRON_PATH}")
-            if self._setup_info and self._setup_info[
-                const.STORAGE_TYPE] == const.STORAGE_TYPE_VIRTUAL:
-                sed_script = f'\
-                    s/\\(.*es_cleanup.*-d\\s\\+\\)[0-9]\\+/\\1{const.ES_CLEANUP_PERIOD_VIRTUAL}/'
-                sed_cmd = f"sed -i -e {sed_script} {const.DEST_CRON_PATH}"
-                Setup._run_cmd(sed_cmd)
-        else:
-            raise CsmSetupError(f"cron failed. {const.CRON_DIR} dir missing.")
-
-    def _logrotate(self):
-        """
-        Configure logrotate
-        """
-        Log.info("Configuring logrotate.")
-        source_logrotate_conf = const.SOURCE_LOGROTATE_PATH
-        if not os.path.exists(const.LOGROTATE_DIR_DEST):
-            Setup._run_cmd(f"mkdir -p {const.LOGROTATE_DIR_DEST}")
-        if os.path.exists(const.LOGROTATE_DIR_DEST):
-            Setup._run_cmd(f"cp -f {source_logrotate_conf} {const.CSM_LOGROTATE_DEST}")
-            csm_agent_log_conf_data = Text(const.CSM_LOGROTATE_DEST).load()
-            if not csm_agent_log_conf_data:
-                Log.warn(f"File {const.CSM_LOGROTATE_DEST} not updated.")
-            else:
-                updated_data = csm_agent_log_conf_data.replace("<CSM_AGENT_LOG_PATH>",
-                                                   self._get_log_path_from_conf_store())
-                Text(const.CSM_LOGROTATE_DEST).dump(updated_data)
-            if (self._setup_info and self._setup_info[
-                const.STORAGE_TYPE] == const.STORAGE_TYPE_VIRTUAL):
-                sed_script = f's/\\(.*rotate\\s\\+\\)[0-9]\\+/\\1{const.LOGROTATE_AMOUNT_VIRTUAL}/'
-                sed_cmd = f"sed -i -e {sed_script} {const.CSM_LOGROTATE_DEST}"
-                Setup._run_cmd(sed_cmd)
-            Setup._run_cmd(f"chmod 644 {const.CSM_LOGROTATE_DEST}")
-        else:
-            err_msg = f"logrotate failed. {const.LOGROTATE_DIR_DEST} dir missing."
-            Log.error(err_msg)
-            raise CsmSetupError(err_msg)
-
-    def _fetch_management_ip(self):
-        cluster_id = Conf.get(const.CONSUMER_INDEX, self.conf_store_keys[const.KEY_CLUSTER_ID])
-        virtual_host_key = f"{const.CLUSTER}>{cluster_id}>{const.NETWORK}>{const.MANAGEMENT}>{const.VIRTUAL_HOST}"
-        self._validate_conf_store_keys(const.CONSUMER_INDEX,[virtual_host_key])
-        virtual_host = Conf.get(const.CONSUMER_INDEX, virtual_host_key)
-        Log.info(f"Fetch Virtual host: {virtual_host}")
-        return virtual_host
-
-    def _configure_uds_keys(self):
-        Log.info("Configuring UDS keys")
-        virtual_host = self._fetch_management_ip()
-        data_nw_public_fqdn = Conf.get(const.CONSUMER_INDEX, self.conf_store_keys[const.KEY_DATA_NW_PUBLIC_FQDN] )
-        Log.debug(f"Validating connectivity for data_nw_public_fqdn:{data_nw_public_fqdn}")
-        try:
-            NetworkV().validate('connectivity', [data_nw_public_fqdn])
-        except Exception as e:
-            Log.error(f"Network Validation failed. {e}")
-            raise CsmSetupError("Network Validation failed.")
-        Log.info(f"Set virtual_host:{virtual_host}, data_nw_public_fqdn:{data_nw_public_fqdn} to csm uds config")
-        Conf.set(const.CSM_GLOBAL_INDEX, f"{const.PROVISIONER}>{const.VIRTUAL_HOST}", virtual_host)
-        Conf.set(const.CSM_GLOBAL_INDEX, f"{const.PROVISIONER}>{const.PUBLIC_DATA_DOMAIN_NAME}", data_nw_public_fqdn)
-
-    def _configure_csm_web_keys(self):
-        if not os.path.exists(const.CSM_WEB_DIST_ENV_FILE_PATH):
-            Log.warn(f"{const.CSM_WEB_DIST_ENV_FILE_PATH} not exists.")
-            return None
-        Setup._run_cmd(f"cp {const.CSM_WEB_DIST_ENV_FILE_PATH} {const.CSM_WEB_DIST_ENV_FILE_PATH}_tmpl")
-        Log.info("Configuring CSM Web keys")
-        virtual_host = self._fetch_management_ip()
-        Log.info(f"Set MANAGEMENT_IP:{virtual_host} to csm web config")
-        file_data = Text(const.CSM_WEB_DIST_ENV_FILE_PATH)
-        data = file_data.load().split("\n")
-        for ele in data:
-            if "MANAGEMENT_IP" in ele:
-                data.remove(ele)
-        data.append(f"MANAGEMENT_IP={virtual_host}")
-        file_data.dump(("\n").join(data))
 
     async def _set_unsupported_feature_info(self):
         """

--- a/csm/conf/prepare.py
+++ b/csm/conf/prepare.py
@@ -73,10 +73,6 @@ class Prepare(Setup):
             return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
         self._prepare_and_validate_confstore_keys()
-        if not Setup.is_k8s_env:
-            self._set_deployment_mode()
-            self._set_fqdn_for_nodeid()
-            self._set_password_to_csm_user()
         self._set_secret_string_for_decryption()
         self._set_cluster_id()
         self._set_ldap_servers()
@@ -87,21 +83,7 @@ class Prepare(Setup):
         return Response(output=const.CSM_SETUP_PASS, rc=CSM_OPERATION_SUCESSFUL)
 
     def _prepare_and_validate_confstore_keys(self):
-        if not Setup.is_k8s_env:
-            self.conf_store_keys.update({
-                const.KEY_SERVER_NODE_INFO:f"{const.SERVER_NODE}>{self.machine_id}",
-                const.KEY_SERVER_NODE_TYPE:f">{const.TYPE}",
-                const.KEY_ENCLOSURE_ID:f"{const.SERVER_NODE}>{self.machine_id}>{const.STORAGE}>{const.ENCLOSURE_ID}",
-                const.KEY_DATA_NW_PRIVATE_FQDN:f"{const.SERVER_NODE}>{self.machine_id}>{const.NETWORK}>{const.DATA}>{const.PRIVATE_FQDN}",
-                const.KEY_HOSTNAME:f"{const.SERVER_NODE}>{self.machine_id}>{const.HOSTNAME}",
-                const.KEY_CLUSTER_ID:f"{const.SERVER_NODE}>{self.machine_id}>{const.CLUSTER_ID}",
-                const.KEY_CSM_LDAP_USER:f"{const.CORTX}>{const.SOFTWARE}>{const.OPENLDAP}>{const.SGIAM}>{const.USER}",
-                const.KEY_CSM_LDAP_SECRET:f"{const.CORTX}>{const.SOFTWARE}>{const.OPENLDAP}>{const.SGIAM}>{const.SECRET}",
-                const.KEY_CSM_USER:f"{const.CORTX}>{const.SOFTWARE}>{const.NON_ROOT_USER}>{const.USER}",
-                const.KEY_CSM_SECRET:f"{const.CORTX}>{const.SOFTWARE}>{const.NON_ROOT_USER}>{const.SECRET}"
-                })
-        else:
-            self.conf_store_keys.update({
+        self.conf_store_keys.update({
                 const.KEY_SERVER_NODE_INFO:f"{const.NODE}>{self.machine_id}",
                 const.KEY_SERVER_NODE_TYPE:f"{const.ENV_TYPE_KEY}",
                 const.KEY_HOSTNAME:f"{const.NODE}>{self.machine_id}>{const.HOSTNAME}",
@@ -129,9 +111,7 @@ class Prepare(Setup):
         eg: for "cortx>software>csm>secret" root is "cortx"
         '''
         Log.info("Set decryption keys for CSM and S3")
-        if not Setup.is_k8s_env:
-            Conf.set(const.CSM_GLOBAL_INDEX, f"{const.CSM}>password_decryption_key",
-                        self.conf_store_keys[const.KEY_CSM_SECRET].split('>')[0])
+
         Conf.set(const.CSM_GLOBAL_INDEX, f"{const.S3}>password_decryption_key",
                     self.conf_store_keys[const.KEY_CSM_LDAP_SECRET].split('>')[0])
 
@@ -141,29 +121,6 @@ class Prepare(Setup):
         if not cluster_id:
             raise CsmSetupError("Failed to fetch cluster id")
         Conf.set(const.CSM_GLOBAL_INDEX, const.CLUSTER_ID_KEY, cluster_id)
-
-    def _set_fqdn_for_nodeid(self):
-        Log.info("Setting hostname to server node name")
-        server_node_info = Conf.get(const.CONSUMER_INDEX, const.SERVER_NODE)
-        Log.debug(f"Server node information: {server_node_info}")
-        for machine_id, node_data in server_node_info.items():
-            hostname = node_data.get(const.HOSTNAME, const.NAME)
-            node_name = node_data.get(const.NAME)
-            Conf.set(const.CSM_GLOBAL_INDEX, f"{const.MAINTENANCE}>{node_name}",f"{hostname}")
-
-    def _get_consul_info(self):
-        """
-        Obtains list of consul host address
-        :return: list of ip where consule is running
-        """
-        Log.info("Fetching data N/W info.")
-        data_nw_private_fqdn = Conf.get(const.CONSUMER_INDEX, self.conf_store_keys[const.KEY_DATA_NW_PRIVATE_FQDN])
-        try:
-            NetworkV().validate('connectivity', [data_nw_private_fqdn])
-        except VError as e:
-            Log.error(f"Network Validation failed.{e}")
-            raise CsmSetupError(f"Network Validation failed.{e}")
-        return [data_nw_private_fqdn]
 
     def _get_consul_config(self):
         endpoint = Conf.get(const.CONSUMER_INDEX, self.conf_store_keys[const.CONSUL_ENDPOINTS_KEY])
@@ -176,43 +133,20 @@ class Prepare(Setup):
         Log.info(f"Fetching consul endpoint : {endpoint}")
         return protocol, [host], port, secret, endpoint
 
-    def _get_es_hosts_info(self):
-    	"""
-        Obtains list of elasticsearch hosts ip running in a cluster
-    	:return: list of elasticsearch hosts ip running in a cluster
-    	"""
-    	Log.info("Fetching data N/W info.")
-    	server_node_info = Conf.get(const.CONSUMER_INDEX, const.SERVER_NODE)
-    	data_nw_private_fqdn_list = []
-    	for machine_id, node_data in server_node_info.items():
-            data_nw_private_fqdn_list.append(node_data["network"]["data"]["private_fqdn"])
-    	try:
-            NetworkV().validate('connectivity', data_nw_private_fqdn_list)
-    	except VError as e:
-            Log.error(f"Network Validation failed.{e}")
-            raise CsmSetupError(f"Network Validation failed.{e}")
-    	return data_nw_private_fqdn_list
-
     def _get_ldap_hosts_info(self):
         """
         Obtains list of ldap host address
         :return: list of ip where ldap is running
         """
         Log.info("Fetching ldap hosts info.")
-        #ToDo: Confstore key may change
-        if Setup.is_k8s_env:
-            ldap_endpoints = Conf.get(const.CONSUMER_INDEX, self.conf_store_keys[const.OPENLDAP_ENDPOINTS])
-            if ldap_endpoints:
-                Log.info(f"Fetching ldap endpoint.{ldap_endpoints}")
-                protocol, host, port = self._parse_endpoints(ldap_endpoints)
-                # resolved_ip = socket.gethostbyname(host)
-                return [host], port
-            else:
-                raise CsmSetupError("LDAP endpoints not found.")
-        Log.info("Fetching data N/W info.")
-        data_nw_private_fqdn = Conf.get(const.CONSUMER_INDEX, self.conf_store_keys[const.KEY_DATA_NW_PRIVATE_FQDN])
-        resolved_ip = socket.gethostbyname(data_nw_private_fqdn)
-        return [resolved_ip], const.DEFAULT_OPENLDAP_PORT
+        ldap_endpoints = Conf.get(const.CONSUMER_INDEX, self.conf_store_keys[const.OPENLDAP_ENDPOINTS])
+        if ldap_endpoints:
+            Log.info(f"Fetching ldap endpoint.{ldap_endpoints}")
+            protocol, host, port = self._parse_endpoints(ldap_endpoints)
+            # resolved_ip = socket.gethostbyname(host)
+            return [host], port
+        else:
+            raise CsmSetupError("LDAP endpoints not found.")
 
     def _set_ldap_servers(self):
         ldap_servers = Conf.get(const.CONSUMER_INDEX, self.conf_store_keys[const.OPENLDAP_SERVERS])
@@ -224,26 +158,15 @@ class Prepare(Setup):
         :return:
         """
         ldap_hosts, ldap_port = self._get_ldap_hosts_info()
-        if  not Setup.is_k8s_env:
-            es_host = self._get_es_hosts_info()
-            consul_host = self._get_consul_info()
-        else:
-            protocols, consul_host, consul_port, secret, endpoints = self._get_consul_config()
-            consul_login = Conf.get(const.CONSUMER_INDEX, const.CONSUL_ADMIN_KEY)
+        protocols, consul_host, consul_port, secret, endpoints = self._get_consul_config()
+        consul_login = Conf.get(const.CONSUMER_INDEX, const.CONSUL_ADMIN_KEY)
         try:
-            if  not Setup.is_k8s_env:
-                Conf.set(const.DATABASE_INDEX, 'databases>es_db>config>hosts', es_host)
-                Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>hosts', consul_host)
-                Conf.set(const.DATABASE_INDEX, 'databases>openldap>config>hosts', ldap_hosts)
-                Conf.set(const.DATABASE_INDEX, 'databases>openldap>config>port', ldap_port)
-            else:
-                Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>hosts', consul_host)
-                Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>port', consul_port)
-                Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>password', secret)
-                Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>login', consul_login)
-                Conf.set(const.DATABASE_INDEX, 'databases>openldap>config>hosts', ldap_hosts)
-                Conf.set(const.DATABASE_INDEX, 'databases>openldap>config>port', ldap_port)
-
+            Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>hosts', consul_host)
+            Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>port', consul_port)
+            Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>password', secret)
+            Conf.set(const.DATABASE_INDEX, 'databases>consul_db>config>login', consul_login)
+            Conf.set(const.DATABASE_INDEX, 'databases>openldap>config>hosts', ldap_hosts)
+            Conf.set(const.DATABASE_INDEX, 'databases>openldap>config>port', ldap_port)
         except Exception as e:
             Log.error(f'Unable to set host address: {e}')
             raise CsmSetupError(f'Unable to set host address: {e}')
@@ -264,17 +187,6 @@ class Prepare(Setup):
             Conf.set(const.DATABASE_INDEX, 'databases>openldap>config>login', f"cn={csm_ldap_user},{base_dn}")
             Conf.set(const.DATABASE_INDEX, 'databases>openldap>config>password', csm_ldap_secret)
 
-    def _set_password_to_csm_user(self):
-        if not self._is_user_exist():
-
-            raise CsmSetupError(f"{self._user} not created on system.")
-        Log.info("Fetch decrypted password.")
-        _password = self._fetch_csm_user_password(decrypt=True)
-        if not _password:
-            Log.error("CSM Password Not Available.")
-            raise CsmSetupError("CSM Password Not Available.")
-        _password = crypt.crypt(_password, "22")
-        Setup._run_cmd(f"usermod -p {_password} {self._user}")
 
     def store_encrypted_password(self):
         """

--- a/csm/conf/setup.py
+++ b/csm/conf/setup.py
@@ -618,14 +618,6 @@ class Setup:
         return env_type == const.K8S
 
     @staticmethod
-    def _copy_systemd_configuration():
-        if Setup.is_k8s_env:
-            Log.warn('SystemD is not used in this environment and will not be set up')
-            return
-        Setup._run_cmd(f"cp {const.CSM_AGENT_SERVICE_SRC_PATH} {const.CSM_AGENT_SERVICE_FILE_PATH}")
-        Setup._run_cmd(f"cp {const.CSM_WEB_SERVICE_SRC_PATH} {const.CSM_WEB_SERVICE_FILE_PATH}")
-
-    @staticmethod
     def _update_systemd_conf(key, value):
         """
         Update CSM Files Depending on Job Type of Setup.

--- a/csm/core/services/sessions.py
+++ b/csm/core/services/sessions.py
@@ -260,12 +260,13 @@ class LoginService:
         if user:
             credentials = await self._auth_service.authenticate(user, password)
 
-        if not credentials:
-            # TODO: Try to search Customer LDAP or S3 account
-            # and create corresponding user record if found.
-            Log.debug(f'User {user_id} does not exist in the local database - trying S3 account')
-            user = User.instantiate_s3_account_user(user_id)
-            credentials = await self._auth_service.authenticate(user, password)
+        # TODO: Commenting S3 login mechanism. Uncomment to support it again in future
+        # if not credentials:
+        #     # TODO: Try to search Customer LDAP or S3 account
+        #     # and create corresponding user record if found.
+        #     Log.debug(f'User {user_id} does not exist in the local database - trying S3 account')
+        #     user = User.instantiate_s3_account_user(user_id)
+        #     credentials = await self._auth_service.authenticate(user, password)
 
         if credentials:
             permissions = await self._role_manager.calc_effective_permissions(user.user_role)


### PR DESCRIPTION
Signed-off-by: Udayan Yaragattikar <udayan.yaragattikar@seagate.com>

# Problem Statement
- https://jts.seagate.com/browse/EOS-27191

# Design
- Commented the S3 login mechanism
- Removed is_K8s check from Miniprovisioing phases

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
Miniprovisioing Pass
![image](https://user-images.githubusercontent.com/66424882/147951713-56acd915-f735-4381-bbe8-be84b54273c2.png)
Configuration Files
![image](https://user-images.githubusercontent.com/66424882/147951751-7cb887f6-6b60-4d8b-b127-8922dfcadfc7.png)
S3 login shows 401: Unautharized
![image](https://user-images.githubusercontent.com/66424882/147951959-14432ef1-6b4e-42a1-acad-c12a9e5f27a3.png)
Csm Login Sucessfull
![image](https://user-images.githubusercontent.com/66424882/147951644-782e18cf-34dc-403f-86bd-2ef0607e8598.png)

  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

