### PR TITLE
EOS-26753: [REST API] REST APIs returns aiohttp and python versions as server header, even if users are unauthorized.

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -366,7 +366,7 @@ class CsmRestApi(CsmApi, ABC):
     @web.middleware
     async def set_secure_headers(request, handler):
         resp = await handler(request)
-        SecureHeaders(csp=True).aiohttp(resp)
+        SecureHeaders(csp=True,server=True).aiohttp(resp)
         return resp
 
     @staticmethod


### PR DESCRIPTION
# Problem Statement
- REST APIs returns aiohttp and python versions as server header, even if users are unauthorized

# Design
-  Set Server header field to NULL

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide

Signed-off-by: Shri Metta <shri.metta@seagate.com>