### PR TITLE
EOS-28031: Support bundle enhancement for adding time filter

### DIFF
--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -137,21 +137,18 @@ class GenerateCsmBundle:
         GenerateCsmBundle.stacktrace = args[const.SB_STACKTRACE]
         target_path = os.path.join(GenerateCsmBundle.target_path, const.CSM_COMPONENT_NAME)
         os.makedirs(target_path,exist_ok=True)
-
         csm_size_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
-            f"{const.CSM_COMPONENT_NAME}_logs_")
+            f"{const.CSM_COMPONENT_NAME}_logs_size")
         GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)
         os.makedirs(csm_size_filtered_logs_dir,exist_ok=True)
         csm_time_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
-            f"{const.CSM_COMPONENT_NAME}_logs_")
+            f"{const.CSM_COMPONENT_NAME}_logs_time")
         GenerateCsmBundle.__clear_tmp_files(csm_time_filtered_logs_dir)
         os.makedirs(csm_time_filtered_logs_dir,exist_ok=True)
         FilterLog.limit_time(csm_log_path, csm_time_filtered_logs_dir,
             GenerateCsmBundle.duration, const.CSM_COMPONENT_NAME)
-
         FilterLog.limit_size(csm_time_filtered_logs_dir, csm_size_filtered_logs_dir,
             GenerateCsmBundle.size_limit, const.CSM_COMPONENT_NAME)
-        
         tar_file_name = os.path.join(target_path, f"{GenerateCsmBundle.bundle_id}.tar.gz")
         Tar(tar_file_name).dump([csm_size_filtered_logs_dir])
         GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)

--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -142,12 +142,10 @@ class GenerateCsmBundle:
             f"{const.CSM_COMPONENT_NAME}_logs_")
         GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)
         os.makedirs(csm_size_filtered_logs_dir,exist_ok=True)
-        
         csm_time_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
             f"{const.CSM_COMPONENT_NAME}_logs_")
         GenerateCsmBundle.__clear_tmp_files(csm_time_filtered_logs_dir)
         os.makedirs(csm_time_filtered_logs_dir,exist_ok=True)
-
         FilterLog.limit_time(csm_log_path, csm_time_filtered_logs_dir,
             GenerateCsmBundle.duration, const.CSM_COMPONENT_NAME)
 

--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -137,19 +137,24 @@ class GenerateCsmBundle:
         GenerateCsmBundle.stacktrace = args[const.SB_STACKTRACE]
         target_path = os.path.join(GenerateCsmBundle.target_path, const.CSM_COMPONENT_NAME)
         os.makedirs(target_path,exist_ok=True)
-        csm_size_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
-            f"{const.CSM_COMPONENT_NAME}_logs_size")
-        GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)
-        os.makedirs(csm_size_filtered_logs_dir,exist_ok=True)
+        # Apply Time filter on CSM Logs Default: P5d
         csm_time_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
             f"{const.CSM_COMPONENT_NAME}_logs_time")
         GenerateCsmBundle.__clear_tmp_files(csm_time_filtered_logs_dir)
         os.makedirs(csm_time_filtered_logs_dir,exist_ok=True)
         FilterLog.limit_time(csm_log_path, csm_time_filtered_logs_dir,
             GenerateCsmBundle.duration, const.CSM_COMPONENT_NAME)
+        # Create directory to keep filtered logs 
+        csm_size_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
+            f"{const.CSM_COMPONENT_NAME}_logs")
+        GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)
+        os.makedirs(csm_size_filtered_logs_dir,exist_ok=True)
+        # Apply Size filter on Time Filtered CSM Logs
         FilterLog.limit_size(csm_time_filtered_logs_dir, csm_size_filtered_logs_dir,
             GenerateCsmBundle.size_limit, const.CSM_COMPONENT_NAME)
+        # Create tar file name with bundle id 
         tar_file_name = os.path.join(target_path, f"{GenerateCsmBundle.bundle_id}.tar.gz")
+        # Tar Directory of filtered logs
         Tar(tar_file_name).dump([csm_size_filtered_logs_dir])
         GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)
         GenerateCsmBundle.__clear_tmp_files(csm_time_filtered_logs_dir)

--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -139,25 +139,25 @@ class GenerateCsmBundle:
         os.makedirs(target_path,exist_ok=True)
 
         csm_size_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
-            f"{const.CSM_COMPONENT_NAME}_logs_size")
+            f"{const.CSM_COMPONENT_NAME}_logs_")
         GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)
         os.makedirs(csm_size_filtered_logs_dir,exist_ok=True)
-        csm_size_time_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
-            f"{const.CSM_COMPONENT_NAME}_logs_size_time")
-        GenerateCsmBundle.__clear_tmp_files(csm_size_time_filtered_logs_dir)
-        os.makedirs(csm_size_time_filtered_logs_dir,exist_ok=True)
-        FilterLog.limit_size(csm_log_path, csm_size_filtered_logs_dir,
+        
+        csm_time_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
+            f"{const.CSM_COMPONENT_NAME}_logs_")
+        GenerateCsmBundle.__clear_tmp_files(csm_time_filtered_logs_dir)
+        os.makedirs(csm_time_filtered_logs_dir,exist_ok=True)
+
+        FilterLog.limit_time(csm_log_path, csm_time_filtered_logs_dir,
+            GenerateCsmBundle.duration, const.CSM_COMPONENT_NAME)
+
+        FilterLog.limit_size(csm_time_filtered_logs_dir, csm_size_filtered_logs_dir,
             GenerateCsmBundle.size_limit, const.CSM_COMPONENT_NAME)
-
-        # TODO: Uncomment limit_time filter once EOS-27275 is resolved.
-        # TODO: And then change the input dir of Tar.dump()
-        # FilterLog.limit_time(csm_size_filtered_logs_dir, csm_size_time_filtered_logs_dir,
-        #     GenerateCsmBundle.duration, const.CSM_COMPONENT_NAME)
-
+        
         tar_file_name = os.path.join(target_path, f"{GenerateCsmBundle.bundle_id}.tar.gz")
         Tar(tar_file_name).dump([csm_size_filtered_logs_dir])
         GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)
-        GenerateCsmBundle.__clear_tmp_files(csm_size_time_filtered_logs_dir)
+        GenerateCsmBundle.__clear_tmp_files(csm_time_filtered_logs_dir)
 
     @staticmethod
     def str2bool(value):

--- a/csm/cli/support_bundle/csm_bundle_generate.py
+++ b/csm/cli/support_bundle/csm_bundle_generate.py
@@ -144,7 +144,7 @@ class GenerateCsmBundle:
         os.makedirs(csm_time_filtered_logs_dir,exist_ok=True)
         FilterLog.limit_time(csm_log_path, csm_time_filtered_logs_dir,
             GenerateCsmBundle.duration, const.CSM_COMPONENT_NAME)
-        # Create directory to keep filtered logs 
+        # Create directory to keep filtered logs
         csm_size_filtered_logs_dir = os.path.join(const.CSM_SETUP_LOG_DIR,
             f"{const.CSM_COMPONENT_NAME}_logs")
         GenerateCsmBundle.__clear_tmp_files(csm_size_filtered_logs_dir)
@@ -152,7 +152,7 @@ class GenerateCsmBundle:
         # Apply Size filter on Time Filtered CSM Logs
         FilterLog.limit_size(csm_time_filtered_logs_dir, csm_size_filtered_logs_dir,
             GenerateCsmBundle.size_limit, const.CSM_COMPONENT_NAME)
-        # Create tar file name with bundle id 
+        # Create tar file name with bundle id
         tar_file_name = os.path.join(target_path, f"{GenerateCsmBundle.bundle_id}.tar.gz")
         # Tar Directory of filtered logs
         Tar(tar_file_name).dump([csm_size_filtered_logs_dir])


### PR DESCRIPTION
Signed-off-by: abhijit1patil <abhijit.1.patil@seagate.com>

# Problem Statement
-[EOS-28031](https://jts.seagate.com/browse/EOS-28031) - Support bundle enhancement for adding time filter

# Design
    #NOTE: Below are the additional arguments, that all component specific Support Bundle script should accept.
    # --duration -> ISO 8061 format, "P" separates, the start datetime and duration to be considered after that. "T" separated date and time. Default is P5d.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
Testcase 1 (Only Duration Filter): - csm agent logs are filtered based on the Duration filter
![eos28392-1](https://user-images.githubusercontent.com/97273554/152161399-76546e02-21ce-4bf2-84dc-2a364b529c2e.png)

TestCase 2: Support bundle with Size and Duration Filter
![eos28392-2](https://user-images.githubusercontent.com/97273554/152161419-fba67f55-c462-40ed-bb4a-c945c587eba6.png)

Testcase 3: Support Bundle generation for Cortex
![eos28392-3](https://user-images.githubusercontent.com/97273554/152161445-f111cc4b-a46d-4d09-88cf-43425d75e414.png)


  Checklist for Author
- [x] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
