### PR TITLE
CORTX-28923: [RGW] Raising validation error for unknown fields in IAM APIs

### DIFF
--- a/csm/core/controllers/rgw/s3/users.py
+++ b/csm/core/controllers/rgw/s3/users.py
@@ -76,7 +76,7 @@ class S3IAMUserListView(S3BaseView):
                   f" user_id: {self.request.session.credentials.user_id}")
         try:
             schema = UserCreateSchema()
-            user_body = schema.load(await self.request.json(), unknown='EXCLUDE')
+            user_body = schema.load(await self.request.json())
             Log.debug(f"Handling create s3 iam user PUT request"
                   f" request body: {user_body}")
         except json.decoder.JSONDecodeError:
@@ -85,7 +85,7 @@ class S3IAMUserListView(S3BaseView):
             raise InvalidRequest(f"{ValidationErrorFormatter.format(val_err)}")
         with self._guard_service():
             response = await self._service.create_user(**user_body)
-            return CsmResponse(response)
+            return CsmResponse(response, const.STATUS_CREATED)
 
 @CsmView._app_routes.view("/api/v2/s3/iam/users/{uid}")
 class S3IAMUserView(S3BaseView):
@@ -128,7 +128,7 @@ class S3IAMUserView(S3BaseView):
         path_params_dict = {const.RGW_JSON_UID: uid}
         try:
             schema = UserDeleteSchema()
-            request_body_params_dict = schema.load(await self.request.json(), unknown='EXCLUDE')
+            request_body_params_dict = schema.load(await self.request.json())
         except json.decoder.JSONDecodeError:
             request_body_params_dict = {}
         except ValidationError as val_err:

--- a/schema/roles.json
+++ b/schema/roles.json
@@ -49,7 +49,8 @@
             "auditlog": ["list", "read"],
             "replace_node": ["list"],
             "health": ["list"],
-            "security": ["read"]
+            "security": ["read"],
+            "s3_iam_users": ["list"]
         }
     },
     "s3": {


### PR DESCRIPTION
Signed-off-by: rohitkolapkar <rohit.j.kolapkar@seagate.com>

# Problem Statement
[CORTX-28923: CRUD API operation should throw "InvalidKey" error with invalid parameters.(IAM users)](https://jts.seagate.com/browse/CORTX-28923)

# Design
-  For Bug, Describe the fix here.
Earlier any random keys in request body params were getting excluded. Now we are raising validation error for unknown keys in request body so that user will get to know he/she has given wrong body params.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide

#Tesing Screenshots
1. Unknown Field error
<img width="884" alt="error for unknown field" src="https://user-images.githubusercontent.com/36843912/155084406-f565af86-2b88-4a2e-a6cc-c57029e8102b.PNG">

2. 201 response for user creation
<img width="911" alt="201" src="https://user-images.githubusercontent.com/36843912/155084475-78d5dc59-36e8-4e48-af6c-a712e077d0b0.PNG">
