### PR TITLE
F45I: rename RGWAdminClient to S3SignedClient

### DIFF
--- a/csm/plugins/cortx/rgw.py
+++ b/csm/plugins/cortx/rgw.py
@@ -21,8 +21,8 @@ from csm.common.errors import CsmInternalError
 from csm.common.payload import Json
 from cortx.utils.log import Log
 from csm.core.blogic import const
-from cortx.utils.s3 import S3SignedClient
-from cortx.utils.s3 import S3SignedClientException
+from cortx.utils.s3 import S3Client
+from cortx.utils.s3 import S3ClientException
 
 
 class RGWPlugin:
@@ -32,7 +32,7 @@ class RGWPlugin:
         Initialize RGW plugin
         """
         config = CsmRgwConfigurationFactory.get_rgw_connection_config()
-        self._rgw_admin_client = S3SignedClient(config.auth_user_access_key,
+        self._rgw_admin_client = S3Client(config.auth_user_access_key,
             config.auth_user_secret_key, config.host, config.port)
         self._api_operations = Json(const.RGW_ADMIN_OPERATIONS_MAPPING_SCHEMA).load()
 
@@ -59,7 +59,7 @@ class RGWPlugin:
             if code != api_operation['SUCCESS_CODE']:
                 return self._create_error(code, response_body)
             return response_body
-        except S3SignedClientException as rgwe:
+        except S3ClientException as rgwe:
             Log.error(f'{const.RGW_CLIENT_ERROR_MSG}: {rgwe}')
             raise CsmInternalError(const.RGW_CLIENT_ERROR_MSG)
 

--- a/csm/plugins/cortx/rgw.py
+++ b/csm/plugins/cortx/rgw.py
@@ -21,8 +21,8 @@ from csm.common.errors import CsmInternalError
 from csm.common.payload import Json
 from cortx.utils.log import Log
 from csm.core.blogic import const
-from cortx.utils.rgwadmin import RGWAdminClient
-from cortx.utils.rgwadmin import RGWAdminClientException
+from cortx.utils.s3 import S3SignedClient
+from cortx.utils.s3 import S3SignedClientException
 
 
 class RGWPlugin:
@@ -32,7 +32,7 @@ class RGWPlugin:
         Initialize RGW plugin
         """
         config = CsmRgwConfigurationFactory.get_rgw_connection_config()
-        self._rgw_admin_client = RGWAdminClient(config.auth_user_access_key,
+        self._rgw_admin_client = S3SignedClient(config.auth_user_access_key,
             config.auth_user_secret_key, config.host, config.port)
         self._api_operations = Json(const.RGW_ADMIN_OPERATIONS_MAPPING_SCHEMA).load()
 
@@ -59,7 +59,7 @@ class RGWPlugin:
             if code != api_operation['SUCCESS_CODE']:
                 return self._create_error(code, response_body)
             return response_body
-        except RGWAdminClientException as rgwe:
+        except S3SignedClientException as rgwe:
             Log.error(f'{const.RGW_CLIENT_ERROR_MSG}: {rgwe}')
             raise CsmInternalError(const.RGW_CLIENT_ERROR_MSG)
 


### PR DESCRIPTION
# Problem Statement
- Per Ujjwal's request RGWAdminClient class is renamed to S3SignedClient.

# Design
-  Rename RGWAdminClient to S3SignedClient
-  Rename RGWAdminClientException to S3SignedClientException
- Update imports from `cortx.utils.rgwadmin` to `cortx.utils.s3`

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
