### PR TITLE
CORTX-28027:Update status api to query for bytecount

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -390,11 +390,10 @@ class CsmRestApi(CsmApi, ABC):
                             lower_key.find("secret") > -1    :
                             del(request_body[key])
             payload = json.dumps(request_body)
-            # TODO: This will be uncommented when unsupported feature is enable
-            #try:
-                #await CsmRestApi.check_for_unsupported_endpoint(request)
-            #except DataAccessError as e:
-                #Log.warn(f"Exception: {e}")
+            try:
+                await CsmRestApi.check_for_unsupported_endpoint(request)
+            except DataAccessError as e:
+                Log.warn(f"Exception: {e}")
             resp = await handler(request)
             if isinstance(resp, DownloadFileEntity):
                 file_resp = web.FileResponse(resp.path_to_file)

--- a/csm/core/controllers/storage_capacity.py
+++ b/csm/core/controllers/storage_capacity.py
@@ -45,7 +45,7 @@ class StorageCapacityView(CsmView):
         return await self._service.get_capacity_details(unit=unit, round_off_value=round_off_value)
 
 
-@CsmView._app_routes.view("/api/v2/cluster/status")
+@CsmView._app_routes.view("/api/v2/capacity/status")
 class CapacityStatusView(CsmView):
     """
     GET REST API view implementation for getting cluster status
@@ -67,7 +67,7 @@ class CapacityStatusView(CsmView):
                                    resp.message)
         return resp
 
-@CsmView._app_routes.view("/api/v2/cluster/status/{capacity_resource}")
+@CsmView._app_routes.view("/api/v2/capacity/status/{capacity_resource}")
 class CapacityManagementView(CsmView):
     """
     GET REST API view implementation for getting cluster status for specific resource


### PR DESCRIPTION
Signed-off-by: Pranali04796 <pranali.ugale@seagate.com>

# Problem Statement:
Updated endpoint from /api/v2/cluster/status/bytecount to /api/v2/capacity/status/bytecount
Expose REST API for fetching Degraded Object Byte count
Update status api to query for bytecount : https://github.com/Seagate/cortx-manager/pull/767

- Jira [CORTX-28027](https://jts.seagate.com/browse/CORTX-28027)

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM
![image](https://user-images.githubusercontent.com/68841079/156500800-f2418154-ce2f-4808-943e-b0b421287a3c.png)
![image](https://user-images.githubusercontent.com/68841079/156539693-c5191775-8789-47a3-abcf-54d1aa9989cd.png)

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
[Design document](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/852000897/F-71E+-+Management+Capacity+Get+Degraded+Capacity+in+Byte+count)
