### PR TITLE
CORTX-29553: Move unsupported features related configurations to consul

### DIFF
--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -167,11 +167,8 @@ COPY_END_TIME=$(date +%s)
 
 ################### BRAND SPECIFIC CHANGES ######################
 if [ "$BRAND_CONFIG_PATH" ]; then
-	cp "$BRAND_CONFIG_PATH/$BRAND_UNSUPPORTED_FEATURES_PATH" "$CORTX_UNSUPPORTED_FEATURES_PATH"
-	echo "updated unsupported_features.json from $BRAND_CONFIG_PATH/$BRAND_UNSUPPORTED_FEATURES_PATH"
-
-	cp "$BRAND_CONFIG_PATH/$BRAND_L18N_PATH" "$CORTX_L18N_PATH"
-	echo "updated l18n.json from $BRAND_CONFIG_PATH/$BRAND_L18N_PATH"
+	echo "Brand specific changes are disabled and take no action"
+	echo "Consider removing BRAND_CONFIG_PATH (-l <path>) when launching the script"
 fi
 
 ################### Dependency ##########################

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -90,6 +90,8 @@ class Configure(Setup):
                 except Exception as e_:
                     Log.warn(f"Unable to connect to ES. Retrying : {count+1}. {e_}")
                     time.sleep(2**count)
+            else:
+                raise CsmSetupError(f"Unable to connect to storage after 4 attempts")
         except ValidationError as ve:
             Log.error(f"Validation Error: {ve}")
             raise CsmSetupError(f"Validation Error: {ve}")


### PR DESCRIPTION
# Problem Statement
- [CORTX-29553](https://jts.seagate.com/browse/CORTX-29553): Move unsupported features related configurations to consul

# Design
-  Disable brand path for unsupported features to get the activate the proper unsupported features schema 
- Raise an exception in case unsupported features database is not accessible

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
