### PR TITLE
CORTX-30331: active users quota

### DIFF
--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -106,7 +106,7 @@ class CsmAgent:
         auth_service = AuthService()
         user_manager = UserManager(db)
         role_manager = RoleManager(roles)
-        session_manager = SessionManager(db)
+        session_manager = QuotaSessionManager(db, const.CSM_ACTIVE_USERS_QUOTA)
         CsmRestApi._app.login_service = LoginService(auth_service,
                                                      user_manager,
                                                      role_manager,
@@ -242,7 +242,7 @@ if __name__ == '__main__':
     from csm.core.services.stats import StatsAppService
     from csm.core.services.users import CsmUserService, UserManager
     from csm.core.services.roles import RoleManagementService, RoleManager
-    from csm.core.services.sessions import SessionManager, LoginService, AuthService
+    from csm.core.services.sessions import QuotaSessionManager, LoginService, AuthService
     from csm.core.repositories.update_status import UpdateStatusRepository
     from csm.core.agent.api import CsmRestApi
     from csm.common.timeseries import TimelionProvider

--- a/csm/core/blogic/const.py
+++ b/csm/core/blogic/const.py
@@ -961,3 +961,6 @@ SESSION_STORAGE_KEY = 'CSM>SESSION>storage'
 SESSION_BACKEND_KEY = 'CSM>SESSION>backend'
 LOCAL               = 'local'
 PERSISTENT          = 'persistent'
+
+# CSM usage quotas
+CSM_ACTIVE_USERS_QUOTA = 50

--- a/csm/core/services/session/session_factory.py
+++ b/csm/core/services/session/session_factory.py
@@ -19,7 +19,7 @@ from csm.core.blogic import const
 from cortx.utils.data.access import Query
 from cortx.utils.data.access.filters import Compare
 from csm.core.services.permissions import PermissionSet
-from datetime import datetime
+from datetime import datetime, timezone
 from csm.core.data.models.session import SessionModel
 from csm.common.errors import CsmInternalError
 from cortx.utils.conf_store.conf_store import Conf
@@ -96,6 +96,10 @@ class Session:
     def get_user_role(self) -> Optional[str]:
         creds = self._credentials
         return creds.user_role if isinstance(creds, LocalCredentials) else None
+
+    def is_expired(self) -> bool:
+        """Check if the session is expired."""
+        return datetime.now(timezone.utc) > self._expiry_time
 
 
 class InMemory:

--- a/csm/core/services/sessions.py
+++ b/csm/core/services/sessions.py
@@ -104,6 +104,101 @@ class SessionManager:
         await self._sessionFactory.store(session)
 
 
+class QuotaSessionManager(SessionManager):
+    """Session manager that tracks usage and maintains usage quotas."""
+
+    def __init__(self, storage: DataBaseProvider, active_users_quota: int) -> None:
+        """
+        Initialize the QuotaSessionManager.
+
+        :param storage: storage for sessions.
+        :param active_users_quota: number of users that are allowed to simultaneously use CSM.
+        :returns: None.
+        """
+        super().__init__(storage)
+        self._active_users_restored = False
+        self._active_users = dict()
+        self._active_users_quota = active_users_quota
+
+    async def _restore_active_users(self):
+        """Restore active users statistics from the session list."""
+        sessions = await self.get_all()
+        for s in sessions:
+            if s.is_expired():
+                await self.delete(s.session_id)
+            else:
+                await self._add_active_user_with_quota(s.credentials.user_id)
+
+    async def _remove_expired_sessions(self):
+        """Remove expired sessions from the storage."""
+        # FIXME: support deletion by query for in-memory Session storage and then
+        # use query to remove expired items.
+        sessions = await self.get_all()
+        for s in sessions:
+            if s.is_expired():
+                await self.delete(s.session_id)
+
+    async def _add_active_user_with_quota(self, user_id: str) -> bool:
+        """
+        Increment the number of sessions for the user with the provided ID if the quota is not full.
+
+        :param user_id: new session user's ID.
+        :returns: True if quota is not full, False otherwise.
+        """
+        if not self._active_users_restored:
+            await self._restore_active_users()
+            self._active_users_restored = True
+        active_users = len(self._active_users)
+        # Try to free space by removing expired sessions
+        if active_users >= self._active_users_quota:
+            await self._remove_expired_sessions()
+        if active_users > self._active_users_quota:
+            return False
+        user_sessions = self._active_users.get(user_id, 0)
+        if active_users == self._active_users_quota and user_sessions == 0:
+            return False
+        self._active_users[user_id] = user_sessions + 1
+
+    def _remove_active_user(self, user_id: str) -> None:
+        """
+        Decrement the number of sessions for the user with the provided ID.
+
+        :param user_id: removed session user's ID.
+        :returns: None.
+        """
+        user_sessions = self._active_users.get(user_id, 0)
+        if user_sessions > 1:
+            self._active_users[user_id] = user_sessions - 1
+        elif user_sessions == 1:
+            del self._active_users[user_id]
+
+    async def create(self, credentials: SessionCredentials, permissions: PermissionSet) -> Session:
+        """
+        Create a new session followint the quota.
+
+        :param credentials: session credentials.
+        :param permissions: session permissions.
+        :returns: Session object.
+        """
+        session = None
+        user_id = credentials.user_id
+        if await self._add_active_user_with_quota(user_id):
+            session = await super().create(credentials, permissions)
+        return session
+
+    async def delete(self, session_id: Session.Id) -> None:
+        """
+        Delete the session updating quota related statistics.
+
+        :param session_id: session ID.
+        :returns: None.
+        """
+        session = await self.get(session_id)
+        user_id = session.credentials.user_id
+        await super().delete(session_id)
+        self._remove_active_user(user_id)
+
+
 class AuthPolicy(ABC):
     """ Base abstract class for various authentication policies """
 

--- a/csm/core/services/sessions.py
+++ b/csm/core/services/sessions.py
@@ -294,28 +294,18 @@ class LoginService:
         Log.debug(f'Logging in user {user_id}')
 
         user = await self._user_manager.get(user_id)
-        credentials = None
-        if user:
-            credentials = await self._auth_service.authenticate(user, password)
-
-        # TODO: Commenting S3 login mechanism. Uncomment to support it again in future
-        # if not credentials:
-        #     # TODO: Try to search Customer LDAP or S3 account
-        #     # and create corresponding user record if found.
-        #     Log.debug(f'User {user_id} does not exist in the local database - trying S3 account')
-        #     user = User.instantiate_s3_account_user(user_id)
-        #     credentials = await self._auth_service.authenticate(user, password)
-
-        if credentials:
-            permissions = await self._role_manager.calc_effective_permissions(user.user_role)
-            session = await self._session_manager.create(credentials, permissions)
-            if session:
-                return session.session_id, {"reset_password": user.reset_password}
-            else:
-                Log.critical(f'Failed to create a new session')
-        else:
+        if user is None:
+            Log.error(f"User with ID - {user_id} - does not exist")
+            return None, None
+        credentials = await self._auth_service.authenticate(user, password)
+        if credentials is None:
             Log.error(f'Failed to authenticate {user_id}')
-        return None, None
+
+        permissions = await self._role_manager.calc_effective_permissions(user.user_role)
+        session = await self._session_manager.create(credentials, permissions)
+        if not session:
+            Log.critical('Failed to create a new session')
+        return session.session_id, {"reset_password": user.reset_password}
 
     async def logout(self, session_id):
         Log.debug(f'Logging out session {session_id}.')


### PR DESCRIPTION
# Problem Statement
- [CORTX-30331](https://jts.seagate.com/browse/CORTX-30331): active users quota.
- Restrict the number of active CSM users to be no more than the provided quota.

# Design
-  Extend the `SessionManager` functionality by introducing the successor class `QuotaSessionManager`
- Keep in-memory statistics of logged-in users and number of sessions per user `{user_id: <number of sessions>}`
- Restore the statistics from the storage at the first session creation request, populate at each login and logout
- Try to clear the storage from expired sessions when the new session doesn't fit the quota.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
