### PR TITLE
CORTX-32075: Fixed: Get user capacity API should throw 'NoSuchUser' for non existing user.

### DIFF
--- a/csm/core/services/storage_capacity.py
+++ b/csm/core/services/storage_capacity.py
@@ -167,10 +167,10 @@ class S3CapacityService(ApplicationService):
 
     async def _get_user_usage(self, **request_body):
         plugin_response = await self._s3_iam_plugin.execute(const.GET_USER_CAPACITY_OPERATION, **request_body)
+        if isinstance(plugin_response, RgwError):
+            ServiceError.create(plugin_response)
         users_dict = plugin_response["capacity"]["s3"]["users"]
         users_list = []
         users_list.append(users_dict.copy())
         plugin_response["capacity"]["s3"]["users"] = users_list
-        if isinstance(plugin_response, RgwError):
-            ServiceError.create(plugin_response)
         return plugin_response

--- a/csm/plugins/cortx/rgw.py
+++ b/csm/plugins/cortx/rgw.py
@@ -117,7 +117,7 @@ class RGWPlugin:
         suppressed_response = response
         keys = self._api_suppress_payload_schema.get(operation)
         if keys:
-            Log.info(f"Suppressing {keys} keys from raw response.")
+            Log.info(f"Suppressing keys from raw response.")
             try:
                 for key in keys:
                     suppressed_response = Utility.remove_json_key(suppressed_response, key)

--- a/csm/plugins/cortx/rgw.py
+++ b/csm/plugins/cortx/rgw.py
@@ -117,7 +117,7 @@ class RGWPlugin:
         suppressed_response = response
         keys = self._api_suppress_payload_schema.get(operation)
         if keys:
-            Log.info(f"Suppressing keys from raw response.")
+            Log.info("Suppressing keys from raw response.")
             try:
                 for key in keys:
                     suppressed_response = Utility.remove_json_key(suppressed_response, key)

--- a/csm/plugins/cortx/rgw.py
+++ b/csm/plugins/cortx/rgw.py
@@ -43,9 +43,7 @@ class RGWPlugin:
     async def execute(self, operation, **kwargs) -> Any:
         api_operation = self._api_operations.get(operation)
         request_body = self._build_request(api_operation['REQUEST_BODY_SCHEMA'], **kwargs)
-        response = await self._process(api_operation, request_body)
-        suppressed_response = self._supress_response_keys(operation, response)
-        return self._build_response(operation, suppressed_response)
+        return await self._process(api_operation, request_body, operation)
 
     @Log.trace_method(Log.DEBUG, exclude_args=['access_key', 'secret_key'])
     def _build_request(self, request_body_schema, **kwargs) -> Any:
@@ -56,13 +54,14 @@ class RGWPlugin:
         return request_body
 
     @Log.trace_method(Log.DEBUG, exclude_args=['access_key', 'secret_key'])
-    async def _process(self, api_operation, request_body) -> Any:
+    async def _process(self, api_operation, request_body, operation) -> Any:
         try:
             (code, body) = await self._rgw_admin_client.signed_http_request(api_operation['METHOD'], api_operation['ENDPOINT'], query_params=request_body)
             response_body = json.loads(body) if body else {}
             if code != api_operation['SUCCESS_CODE']:
                 return self._create_error(code, response_body)
-            return response_body
+            suppressed_response = self._supress_response_keys(operation, response_body)
+            return self._build_response(operation, suppressed_response)
         except S3ClientException as rgwe:
             Log.error(f'{const.S3_CLIENT_ERROR_MSG}: {rgwe}')
             if str(rgwe) == "Request timeout":
@@ -104,7 +103,7 @@ class RGWPlugin:
             except Exception as e:
                 Log.error(f"Error occured while coverting raw api response to\
                     required response: {e}")
-                raise CsmInternalError(const.S3_CLIENT_ERROR_MSG)
+                raise e
         return mapped_response
 
     def _supress_response_keys(self, operation, response) -> Any:
@@ -130,7 +129,7 @@ class RGWPlugin:
                     suppressed_response = Utility.remove_json_key(suppressed_response, key)
             except Exception as e:
                 Log.error(f"Error occured while suppressing {keys} keys from response: {e}")
-                raise CsmInternalError(const.S3_CLIENT_ERROR_MSG)
+                raise e
         return suppressed_response
 
     @staticmethod

--- a/csm/plugins/cortx/rgw.py
+++ b/csm/plugins/cortx/rgw.py
@@ -83,9 +83,6 @@ class RGWPlugin:
             operation (str): IAM operation.
             response (dict): Response from s3 server.
 
-        Raises:
-            CsmInternalError.
-
         Returns:
             Mapped response.
         """
@@ -114,16 +111,13 @@ class RGWPlugin:
             operation (str): IAM operation.
             response (dict): Response from s3 server.
 
-        Raises:
-            CsmInternalError
-
         Returns:
             Modified response.
         """
         suppressed_response = response
         keys = self._api_suppress_payload_schema.get(operation)
-        Log.debug(f"Suppressing {keys} keys from raw response.")
         if keys:
+            Log.info(f"Suppressing {keys} keys from raw response.")
             try:
                 for key in keys:
                     suppressed_response = Utility.remove_json_key(suppressed_response, key)

--- a/schema/iam_operations_mapping.json
+++ b/schema/iam_operations_mapping.json
@@ -7,7 +7,7 @@
     "GET_USER_CAPACITY": {
         "user_id": "capacity.s3.users.id",
         "stats.size": "capacity.s3.users.used",
-        "stats.size_actual": "capacity.s3.users.used_total",
+        "stats.size_actual": "capacity.s3.users.used_rounded",
         "stats.num_objects": "capacity.s3.users.objects"
     }
 }

--- a/schema/iam_operations_mapping.json
+++ b/schema/iam_operations_mapping.json
@@ -7,7 +7,7 @@
     "GET_USER_CAPACITY": {
         "user_id": "capacity.s3.users.id",
         "stats.size": "capacity.s3.users.used",
-        "stats.size_actual": "capacity.s3.users.used_rounded",
+        "stats.size_actual": "capacity.s3.users.used_total",
         "stats.num_objects": "capacity.s3.users.objects"
     }
 }


### PR DESCRIPTION
Signed-off-by: Rohit Kolapkar <rohit.j.kolapkar@seagate.com>

# Pull Request
## Problem Statement
-   [Get user capacity API should throw 'NoSuchUser' for non existing user](https://jts.seagate.com/browse/CORTX-32075)

## Design
-   For Bug, Describe the fix here.
-   For Feature, Post the link for design

## Coding
>   Checklist for Author
-   \[ \] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Unit and System Tests are added
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[ \] Testing was performed with RPM

## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[x] JIRA number/GitHub Issue added to PR
-   \[x] PR is self reviewed
-   \[x] Jira and state/status is updated and JIRA is updated with PR link
-   \[x] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide

##Dev Testing
1. try to fetch capacity stats of non-existing IAM user.
![image](https://user-images.githubusercontent.com/36843912/172183529-74f39c82-e3cb-4438-aca6-3f8f9b4efd71.png)
