### PR TITLE
CORTX-31607: hide 'Server' HTTP header in responses

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -125,6 +125,7 @@ class CsmRestApi(CsmApi, ABC):
             CsmRestApi._app.router, CsmRestApi.process_websocket)
         ApiRoutes.add_swagger_ui_routes(CsmRestApi._app.router)
 
+        CsmRestApi._app.on_response_prepare.append(CsmRestApi._hide_headers)
         CsmRestApi._app.on_startup.append(CsmRestApi._on_startup)
         CsmRestApi._app.on_shutdown.append(CsmRestApi._on_shutdown)
 
@@ -472,6 +473,10 @@ class CsmRestApi(CsmApi, ABC):
                 task.cancel()
         await site.stop()
         loop.stop()
+
+    @staticmethod
+    async def _hide_headers(request, response) -> None:
+        del response.headers['Server']
 
     @staticmethod
     async def _handle_sigint(loop, site):


### PR DESCRIPTION
# Pull Request
## Problem Statement
-   [CORTX-31607](https://jts.seagate.com/browse/CORTX-31607): REST API returns aiohttp and python versions as server header for authorized users.

## Design
-   On `aiohttp` signal remove 'Server' header before the response is sent.

## Coding
>   Checklist for Author
-   \[x\] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Unit and System Tests are added
-   \[x\] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[x\] Testing was performed with RPM

## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[x\] JIRA number/GitHub Issue added to PR
-   \[x\] PR is self reviewed
-   \[x\] Jira and state/status is updated and JIRA is updated with PR link
-   \[x\] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide
