### PR TITLE
CORTX-33726: fix race condition on users quota check

### DIFF
--- a/csm/core/agent/csm_agent.py
+++ b/csm/core/agent/csm_agent.py
@@ -109,7 +109,8 @@ class CsmAgent:
         # S3 service
         CsmAgent._configure_s3_services()
 
-        user_service = CsmUserService(user_manager)
+        max_users_allowed = int(Conf.get(const.CSM_GLOBAL_INDEX, const.CSM_MAX_USERS_ALLOWED))
+        user_service = CsmUserService(user_manager, max_users_allowed)
         CsmRestApi._app[const.CSM_USER_SERVICE] = user_service
         CsmRestApi._app[const.STORAGE_CAPACITY_SERVICE] = StorageCapacityService()
         # CsmRestApi._app[const.UNSUPPORTED_FEATURES_SERVICE] = UnsupportedFeaturesService()

--- a/csm/core/controllers/users.py
+++ b/csm/core/controllers/users.py
@@ -91,12 +91,6 @@ class CsmUsersListView(CsmView):
         self._service = self.request.app["csm_user_service"]
         self._service_dispatch = {}
 
-    async def check_max_user_limit(self):
-        max_users_allowed = int(Conf.get(const.CSM_GLOBAL_INDEX, const.CSM_MAX_USERS_ALLOWED))
-        existing_users_count = await self._service.get_user_count()
-        if existing_users_count >= max_users_allowed and max_users_allowed > 0:
-            raise CsmPermissionDenied("User creation failed. Maximum user limit reached.")
-
     @CsmAuth.permissions({Resource.USERS: {Action.LIST}})
     async def get(self):
         """GET REST implementation for fetching csm users."""
@@ -125,8 +119,6 @@ class CsmUsersListView(CsmView):
             raise InvalidRequest(const.JSON_ERROR)
         except ValidationError as val_err:
             raise InvalidRequest(f"Invalid request body: {val_err}")
-
-        await self.check_max_user_limit()
 
         # TODO: Story has been taken for unsupported services
         # The following commented lines will be removed by above story


### PR DESCRIPTION
# Pull Request
## Problem Statement
-   [CORTX-33726](https://jts.seagate.com/browse/CORTX-33726): Able to create 101th CSM user

## Design
-   Guard create_user mehtod with asyncio.Lock to prevent race condition between getting the current number of users and creating a new one.
## Coding
>   Checklist for Author
-   \[x\] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[\] Unit and System Tests are added
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[ \] Testing was performed with RPM

## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[ \] JIRA number/GitHub Issue added to PR
-   \[ \] PR is self reviewed
-   \[ \] Jira and state/status is updated and JIRA is updated with PR link
-   \[ \] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide
