### PR TITLE
CORTX-33846: Integration with provisioner for query deployment

### DIFF
--- a/csm/core/services/information.py
+++ b/csm/core/services/information.py
@@ -17,7 +17,7 @@ from cortx.utils.log import Log
 from csm.core.blogic import const
 from csm.common.services import ApplicationService
 from cortx.utils.schema.release import Release
-from csm.common.errors import CsmInternalError, InvalidRequest
+from csm.common.errors import CsmInternalError, CsmNotFoundError
 
 class InformationService(ApplicationService):
     """Version Comptibility Validation service class."""
@@ -84,7 +84,7 @@ class InformationService(ApplicationService):
             response[const.TOPOLOGY][resource] = [item for item in \
                 payload if item.get(const.ID) == resource_id]
             if len(response[const.TOPOLOGY][resource]) < 1:
-                raise InvalidRequest(f"Invalid resource_id: {resource_id}")
+                raise CsmNotFoundError(f"Invalid resource_id: {resource_id}")
         return response
 
     @Log.trace_method(Log.DEBUG)
@@ -118,5 +118,5 @@ class InformationService(ApplicationService):
             res[const.TOPOLOGY][resource][0][view] = [item for item in \
                 payload if item.get(const.ID) == view_id]
             if len(res[const.TOPOLOGY][resource][0][view]) < 1:
-                raise InvalidRequest(f"Invalid resource_id: {view_id}")
+                raise CsmNotFoundError(f"Invalid resource_id: {view_id}")
         return res


### PR DESCRIPTION
Signed-off-by: Pranali Ugale <pranali.ugale@seagate.com>

# Pull Request
## Problem Statement
-   Handle negative scenarios as per [REST SPECIFICATION](https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/1024229377/Query+Deployment+REST+API+specification)

## Design
-   For Bug, Describe the fix here.
-   For Feature, Post the link for design

## Coding
>   Checklist for Author
-   \[ \] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Unit and System Tests are added
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[ \] Testing was performed with RPM
-  Invalid resource
![image](https://user-images.githubusercontent.com/68841079/184276233-19e1bf18-d8fc-468c-ac8b-b199e27a85e5.png)
- Invalid resource id
![image](https://user-images.githubusercontent.com/68841079/184276399-d9f901fc-9e66-42a8-9aa9-81b4a11acea5.png)

## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[ \] JIRA number/GitHub Issue added to PR
-   \[ \] PR is self reviewed
-   \[ \] Jira and state/status is updated and JIRA is updated with PR link
-   \[ \] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide
