### PR TITLE
CORTX-32589: [Bug fix] Fixed mapping in capacity response

### DIFF
--- a/csm/core/services/storage_capacity.py
+++ b/csm/core/services/storage_capacity.py
@@ -170,8 +170,6 @@ class S3CapacityService(ApplicationService):
         if isinstance(plugin_response, RgwError):
             ServiceError.create(plugin_response)
         users_dict = plugin_response["capacity"]["s3"]["users"]
-        users_dict["id"] = users_dict["keys"][0]["user"]
-        del users_dict["keys"]
         users_list = []
         users_list.append(users_dict.copy())
         plugin_response["capacity"]["s3"]["users"] = users_list

--- a/csm/core/services/storage_capacity.py
+++ b/csm/core/services/storage_capacity.py
@@ -170,6 +170,8 @@ class S3CapacityService(ApplicationService):
         if isinstance(plugin_response, RgwError):
             ServiceError.create(plugin_response)
         users_dict = plugin_response["capacity"]["s3"]["users"]
+        users_dict["id"] = users_dict["keys"][0]["user"]
+        del users_dict["keys"]
         users_list = []
         users_list.append(users_dict.copy())
         plugin_response["capacity"]["s3"]["users"] = users_list

--- a/schema/iam_operations_mapping.json
+++ b/schema/iam_operations_mapping.json
@@ -5,7 +5,7 @@
         "marker": "marker"
     },
     "GET_USER_CAPACITY": {
-        "user_id": "capacity.s3.users.id",
+        "display_name": "capacity.s3.users.id",
         "stats.size": "capacity.s3.users.used",
         "stats.size_actual": "capacity.s3.users.used_rounded",
         "stats.num_objects": "capacity.s3.users.objects"

--- a/schema/iam_operations_mapping.json
+++ b/schema/iam_operations_mapping.json
@@ -5,7 +5,8 @@
         "marker": "marker"
     },
     "GET_USER_CAPACITY": {
-        "display_name": "capacity.s3.users.id",
+        "user_id": "capacity.s3.users.id",
+        "keys": "capacity.s3.users.keys",
         "stats.size": "capacity.s3.users.used",
         "stats.size_actual": "capacity.s3.users.used_rounded",
         "stats.num_objects": "capacity.s3.users.objects"

--- a/schema/iam_operations_mapping.json
+++ b/schema/iam_operations_mapping.json
@@ -5,8 +5,8 @@
         "marker": "marker"
     },
     "GET_USER_CAPACITY": {
+        "tenant":"capacity.s3.users.tenant",
         "user_id": "capacity.s3.users.id",
-        "keys": "capacity.s3.users.keys",
         "stats.size": "capacity.s3.users.used",
         "stats.size_actual": "capacity.s3.users.used_rounded",
         "stats.num_objects": "capacity.s3.users.objects"


### PR DESCRIPTION
Signed-off-by: Rohit Kolapkar <rohit.j.kolapkar@seagate.com>

# Pull Request
## Problem Statement
-   [Tenant details are missing in the ID field of the GET capacity](https://jts.seagate.com/browse/CORTX-32589)

## Design
-   For Bug, Describe the fix here.
-   For Feature, Post the link for design

## Coding
>   Checklist for Author
-   \[ \] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Unit and System Tests are added
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[ \] Testing was performed with RPM

## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[ \] JIRA number/GitHub Issue added to PR
-   \[ \] PR is self reviewed
-   \[ \] Jira and state/status is updated and JIRA is updated with PR link
-   \[ \] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide

## Dev Testing
<img width="643" alt="image" src="https://user-images.githubusercontent.com/36843912/184855987-f52d026a-9155-47d1-b93c-a5dbf0901098.png">

example 1:

request- GET https://hostname/api/v2/capacity/s3/user/t5$demouser1
response- 
{
    "capacity": {
        "s3": {
            "users": [
                { "tenant": "t5",                     

                  "id": "demouser1",

                   "used": 0,

                   "used_rounded": 0,

                    "objects": 0                 

                }

            ]
        }
    }
}
===============================================
example 2:
 
request- GET https://hostname/api/v2/capacity/s3/user/user1
response- 
{
    "capacity": {
        "s3": {
            "users": [
              {

               "tenant": "",

                "id": "user1",

                "used": 0,

                "used_rounded": 0,

                 "objects": 0                 

               }

            ]
        }
    }
}