### PR TITLE
CORTX-33950: GET IAM user capacity API with tenant as a path param

### DIFF
--- a/csm/core/controllers/storage_capacity.py
+++ b/csm/core/controllers/storage_capacity.py
@@ -131,7 +131,7 @@ class S3CapacityView(CsmView):
             return CsmResponse(response)
 
 
-@CsmView._app_routes.view("/api/v2/capacity/s3/{resource}/{id}/{tenant}")
+@CsmView._app_routes.view("/api/v2/capacity/s3/{tenant}/{resource}/{id}")
 class S3CapacityTenantView(CsmView):
     """
     GET REST API view implementation for getting capacity usage for specific user

--- a/csm/core/controllers/storage_capacity.py
+++ b/csm/core/controllers/storage_capacity.py
@@ -129,3 +129,33 @@ class S3CapacityView(CsmView):
         with ServiceError.guard_service():
             response = await self._service.get_usage(resource, resource_id)
             return CsmResponse(response)
+
+
+@CsmView._app_routes.view("/api/v2/capacity/s3/{resource}/{id}/{tenant}")
+class S3CapacityTenantView(CsmView):
+    """
+    GET REST API view implementation for getting capacity usage for specific user
+    """
+
+    def __init__(self, request):
+        """Get user level capacity usage Init."""
+        super().__init__(request)
+        self._service: S3CapacityService = self.request.app[const.S3_CAPACITY_SERVICE]
+
+    @CsmAuth.permissions({Resource.CAPACITY: {Action.LIST}})
+    @Log.trace_method(Log.DEBUG)
+    async def get(self):
+        resource = self.request.match_info[const.ARG_RESOURCE]
+        resource_id = self.request.match_info[const.ID]
+        tenant = self.request.match_info[const.TENANT]
+        resource_id = tenant+'$'+resource_id
+        Log.info(f"Handling GET s3 capacity request"
+                  f"resource={resource} and id ={resource_id}")
+        try:
+            schema = S3CapacitySchema()
+            schema.load({const.ARG_RESOURCE:resource})
+        except ValidationError as val_err:
+            raise InvalidRequest(f"{ValidationErrorFormatter.format(val_err)}")
+        with ServiceError.guard_service():
+            response = await self._service.get_usage(resource, resource_id)
+            return CsmResponse(response)


### PR DESCRIPTION
Signed-off-by: Rohit Kolapkar <rohit.j.kolapkar@seagate.com>

# Pull Request
## Problem Statement
-  [Rest API implementation to handle tenant details for Capacity API](https://jts.seagate.com/browse/CORTX-33950)

## Design
-   For Bug, Describe the fix here.
-   For Feature, Post the link for design

## Coding
>   Checklist for Author
-   \[x] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Unit and System Tests are added
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[x] Testing was performed with RPM

## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[x] JIRA number/GitHub Issue added to PR
-   \[x] PR is self reviewed
-   \[x] Jira and state/status is updated and JIRA is updated with PR link
-   \[x] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide
## Dev testing
<img width="853" alt="image" src="https://user-images.githubusercontent.com/36843912/186139145-8bb82ded-1da1-40ee-ba2e-9edecc69bb6a.png">

<img width="772" alt="image" src="https://user-images.githubusercontent.com/36843912/186139312-3573b975-7949-4098-aca4-468054f176f7.png">
