### PR TITLE
CORTX-33880 : control pod goes in crash loop if memory limit is set as 1Gi

### DIFF
--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -354,8 +354,25 @@ class Configure(Setup):
         :param mem: value from Conf as string.
         :returns: integer value.
         """
-        numbers_only = mem[:mem.find('M')]
-        return int(numbers_only)
+#         numbers_only = mem[:mem.find('M')]
+#         return int(numbers_only)
+        num = ''
+        unit = ''
+        for char in mem:
+            if ord(char) >= 48 and ord(char) <= 57:
+                num = num + char
+            elif (ord(char) >= 65 and ord(char) <= 90) or (ord(char) >= 97 and ord(char) <= 122):
+                unit += char
+        
+        valueInMib = int(num)
+        if unit == 'G':
+            valueInMib = valueInMib * 1024
+        elif unit == 'T':
+            valueInMib = valueInMib * 1024 * 1024
+        elif unit == 'P':
+            valueInMib = valueInMib * 1024 * 1024 * 1024
+        unit = 'M'
+        return int(valueInMib)
 
     @staticmethod
     def _cpu_limit_to_int(cpu: str) -> int:


### PR DESCRIPTION
Signed-off-by: vaishnavirjoshi <vaishnavi.r.joshi@seagate.com>

# Pull Request
## Problem Statement
-   Problem statement

## Design
-   For Bug, Describe the fix here.
-   For Feature, Post the link for design

## Coding
>   Checklist for Author
-   \[ \] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Unit and System Tests are added
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[ \] Testing was performed with RPM

## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[ \] JIRA number/GitHub Issue added to PR
-   \[ \] PR is self reviewed
-   \[ \] Jira and state/status is updated and JIRA is updated with PR link
-   \[ \] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide
