### PR TITLE
CORTX-33880: podcrash- memory limit converted from Gi, Pi, Ti or G, T, P to MiB

### DIFF
--- a/csm/common/utility.py
+++ b/csm/common/utility.py
@@ -125,7 +125,7 @@ class Utility:
             except (VError, KvError) as e:
                 Log.error(f"Unable to fetch the configurations from consul: {e}")
                 raise e
-                
+
     @staticmethod
     def conversion_mem_limit(intVal, convertFrom, convertTo):
         convertToByte = {'B' : 1, 'K' : 1000, 'M' : 1000**2, 'G' : 1000**3,

--- a/csm/common/utility.py
+++ b/csm/common/utility.py
@@ -128,13 +128,8 @@ class Utility:
                 
      @staticmethod
      def conversion_mem_limit(intVal, convertFrom, convertTo):
-        
-        convertToByte = {
-
-            'B' : 1, 'K' : 1000, 'M' : 1000**2, 'G' : 1000**3, 'T' : 1000 ** 4, 'P' : 1000 ** 5,
-            'Ki' : 1024, 'Mi' : 1024**2, 'Gi' : 1024**3, 'Ti' : 1024 ** 4, 'Pi' : 1024 ** 5,
-        }
+        convertToByte = {'B' : 1, 'K' : 1000, 'M' : 1000**2, 'G' : 1000**3, 'T' : 1000 ** 4, 'P' : 1000 ** 5,'Ki' : 1024, 'Mi' : 1024**2, 'Gi' : 1024**3, 'Ti' : 1024 ** 4, 'Pi' : 1024 ** 5}
         valInByte = convertToByte.get(convertFrom) * intVal
         val = convertToByte.get(convertTo)
         ans = valInByte / val
-        return int(ans)    
+        return int(ans)  

--- a/csm/common/utility.py
+++ b/csm/common/utility.py
@@ -128,8 +128,13 @@ class Utility:
                 
     @staticmethod
     def conversion_mem_limit(intVal, convertFrom, convertTo):
-        convertToByte = {'B' : 1, 'K' : 1000, 'M' : 1000**2, 'G' : 1000**3, 'T' : 1000 ** 4, 'P' : 1000 ** 5,'Ki' : 1024, 'Mi' : 1024**2, 'Gi' : 1024**3, 'Ti' : 1024 ** 4, 'Pi' : 1024 ** 5}
-        valInByte = convertToByte.get(convertFrom) * intVal
+        convertToByte = {'B' : 1, 'K' : 1000, 'M' : 1000**2, 'G' : 1000**3,
+                         'T' : 1000 ** 4, 'P' : 1000 ** 5,'Ki' : 1024, 'Mi' : 1024**2,
+                         'Gi' : 1024**3, 'Ti' : 1024 ** 4, 'Pi' : 1024 ** 5}
+        try:
+            valInByte = convertToByte.get(convertFrom) * intVal
+        except (KeyError) as e:
+            raise e
         val = convertToByte.get(convertTo)
         ans = valInByte / val
-        return int(ans)  
+        return int(ans)

--- a/csm/common/utility.py
+++ b/csm/common/utility.py
@@ -126,8 +126,8 @@ class Utility:
                 Log.error(f"Unable to fetch the configurations from consul: {e}")
                 raise e
                 
-     @staticmethod
-     def conversion_mem_limit(intVal, convertFrom, convertTo):
+    @staticmethod
+    def conversion_mem_limit(intVal, convertFrom, convertTo):
         convertToByte = {'B' : 1, 'K' : 1000, 'M' : 1000**2, 'G' : 1000**3, 'T' : 1000 ** 4, 'P' : 1000 ** 5,'Ki' : 1024, 'Mi' : 1024**2, 'Gi' : 1024**3, 'Ti' : 1024 ** 4, 'Pi' : 1024 ** 5}
         valInByte = convertToByte.get(convertFrom) * intVal
         val = convertToByte.get(convertTo)

--- a/csm/common/utility.py
+++ b/csm/common/utility.py
@@ -125,3 +125,16 @@ class Utility:
             except (VError, KvError) as e:
                 Log.error(f"Unable to fetch the configurations from consul: {e}")
                 raise e
+                
+     @staticmethod
+     def conversion_mem_limit(intVal, convertFrom, convertTo):
+        
+        convertToByte = {
+
+            'B' : 1, 'K' : 1000, 'M' : 1000**2, 'G' : 1000**3, 'T' : 1000 ** 4, 'P' : 1000 ** 5,
+            'Ki' : 1024, 'Mi' : 1024**2, 'Gi' : 1024**3, 'Ti' : 1024 ** 4, 'Pi' : 1024 ** 5,
+        }
+        valInByte = convertToByte.get(convertFrom) * intVal
+        val = convertToByte.get(convertTo)
+        ans = valInByte / val
+        return int(ans)    

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -28,6 +28,7 @@ from cortx.utils.message_bus import MessageBusAdmin,MessageBus
 from cortx.utils.message_bus.error import MessageBusError
 from csm.common.utility import Utility
 from cortx.utils.validator.error import VError
+from csm.common.utility import Utility
 
 
 class Configure(Setup):
@@ -370,22 +371,11 @@ class Configure(Setup):
                 num = num + char
             elif (ord(char) >= 65 and ord(char) <= 90) or (ord(char) >= 97 and ord(char) <= 122):
                 unit += char
-        
-        valueInMib = int(num)
-        if unit == 'G':
-            valueInMib = valueInMib * 1000
-        elif unit == 'T':
-            valueInMib = valueInMib * 1000 * 1000
-        elif unit == 'P':
-            valueInMib = valueInMib * 1000 * 1000 * 1000
-        elif unit == 'Gi':
-            valueInMib = valueInMib * 1024
-        elif unit == 'Ti':
-            valueInMib = valueInMib * 1024 * 1024
-        elif unit == 'Pi':
-            valueInMib = valueInMib * 1024 * 1024 * 1024
-        unit = 'M'
-        return int(valueInMib)
+
+        intVal = int(num)
+        convertFrom = unit
+        convertTo = 'M'
+        return Utility.conversion_mem_limit(intVal, convertFrom, convertTo)
 
     @staticmethod
     def _cpu_limit_to_int(cpu: str) -> int:

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -365,7 +365,7 @@ class Configure(Setup):
         temp = re.compile("([0-9]+)(Gi?|Mi?|Pi?|Ki?|Ti?|B)")
         try:
             memLimit = temp.match(mem).groups()
-            if len(memLimit[1]) == 1: 
+            if len(memLimit[1]) == 1:
                 flag = (len(memLimit[0]) == len(mem)-1)
                 if not (flag): raise AttributeError
             elif len(memLimit[1]) == 2:

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -14,6 +14,7 @@
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
 import os
+import re
 # from cortx.utils.product_features import unsupported_features
 from marshmallow.exceptions import ValidationError
 from csm.common.service_urls import ServiceUrls
@@ -361,18 +362,20 @@ class Configure(Setup):
         :param mem: value from Conf as string.
         :returns: integer value.
         """
-#         numbers_only = mem[:mem.find('M')]
-#         return int(numbers_only)
-        num = ''
-        unit = ''
-        for char in mem:
-            if ord(char) >= 48 and ord(char) <= 57:
-                num = num + char
-            elif (ord(char) >= 65 and ord(char) <= 90) or (ord(char) >= 97 and ord(char) <= 122):
-                unit += char
-
-        intVal = int(num)
-        convertFrom = unit
+        temp = re.compile("([0-9]+)(Gi?|Mi?|Pi?|Ki?|Ti?|B)")
+        try:
+            memLimit = temp.match(mem).groups()
+            if len(memLimit[1]) == 1: 
+                flag = (len(memLimit[0]) == len(mem)-1)
+                if not (flag): raise AttributeError
+            elif len(memLimit[1]) == 2:
+                flag = (len(memLimit[0]) == len(mem)-2)
+                if not (flag): raise AttributeError
+            else:
+                raise AttributeError
+        except(AttributeError) as e:
+            raise e
+        intVal, convertFrom = int(memLimit[0]), memLimit[1]
         convertTo = 'M'
         return Utility.conversion_mem_limit(intVal, convertFrom, convertTo)
 

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -365,11 +365,17 @@ class Configure(Setup):
                 unit += char
         
         valueInMib = int(num)
-        if unit == 'G' or unit == 'Gi':
+        if unit == 'G':
+            valueInMib = valueInMib * 1000
+        elif unit == 'T':
+            valueInMib = valueInMib * 1000 * 1000
+        elif unit == 'P':
+            valueInMib = valueInMib * 1000 * 1000 * 1000
+        elif unit == 'Gi':
             valueInMib = valueInMib * 1024
-        elif unit == 'T' or unit == 'Ti':
+        elif unit == 'Ti':
             valueInMib = valueInMib * 1024 * 1024
-        elif unit == 'P'  or unit == 'Pi':
+        elif unit == 'Pi':
             valueInMib = valueInMib * 1024 * 1024 * 1024
         unit = 'M'
         return int(valueInMib)

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -365,11 +365,11 @@ class Configure(Setup):
                 unit += char
         
         valueInMib = int(num)
-        if unit == 'G':
+        if unit == 'G' or unit == 'Gi':
             valueInMib = valueInMib * 1024
-        elif unit == 'T':
+        elif unit == 'T' or unit == 'Ti':
             valueInMib = valueInMib * 1024 * 1024
-        elif unit == 'P':
+        elif unit == 'P'  or unit == 'Pi':
             valueInMib = valueInMib * 1024 * 1024 * 1024
         unit = 'M'
         return int(valueInMib)

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -354,8 +354,25 @@ class Configure(Setup):
         :param mem: value from Conf as string.
         :returns: integer value.
         """
-        numbers_only = mem[:mem.find('M')]
-        return int(numbers_only)
+#         numbers_only = mem[:mem.find('M')]
+#         return int(numbers_only)
+        num = ''
+        unit = ''
+        for char in mem:
+            if ord(char) >= 48 and ord(char) <= 57:
+                num = num + char
+            elif (ord(char) >= 65 and ord(char) <= 90) or (ord(char) >= 97 and ord(char) <= 122):
+                unit += char
+        
+        valueInMib = int(num)
+        if unit == 'G':
+            valueInMib = valueInMib * 1024
+        elif unit == 'T':
+            valueInMib = valueInMib * 1024 * 1024
+        elif unit == 'P':
+            valueInMib = valueInMib * 1024 * 1024 * 1024
+        unit = 'M'
+        return int(valueInMib)
 
     @staticmethod
     def _cpu_limit_to_int(cpu: str) -> int:

--- a/csm/conf/configure.py
+++ b/csm/conf/configure.py
@@ -28,7 +28,6 @@ from cortx.utils.message_bus import MessageBusAdmin,MessageBus
 from cortx.utils.message_bus.error import MessageBusError
 from csm.common.utility import Utility
 from cortx.utils.validator.error import VError
-from csm.common.utility import Utility
 
 
 class Configure(Setup):


### PR DESCRIPTION
# Pull Request
## Problem Statement
- podcrash- memory limit converted from Gi, Pi, Ti or G, T, P to MiB
-  Jira id : [CORTX-33880](https://jts.seagate.com/browse/CORTX-33880)

##FIX
- Control pod in running after giving memory limit into Ki,  Ki, Gi, Pi, Mi, Ti, K, G, M, B, T, P


## Design
-   For Bug, Describe the fix here.
-   For Feature, Post the link for design

## Coding
>   Checklist for Author
-   \[ \] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Tested by changing solution.yaml file and redeployed cortx. All pods are running. 
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[ \] Testing was performed with RPM
- 
![image](https://user-images.githubusercontent.com/109715245/188557573-6f50eb5f-08aa-401a-81ca-0280b67103af.png)
![image](https://user-images.githubusercontent.com/109715245/188557629-714b8d1f-b7df-4021-bd6d-432261a4b080.png)
![image](https://user-images.githubusercontent.com/109715245/188557807-3ddaefb7-499b-400a-bf07-6f3de589b7f9.png)
![image](https://user-images.githubusercontent.com/109715245/188557921-0972536a-afb3-41fb-bcb7-02876d3c5a73.png)


## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[ \] JIRA number/GitHub Issue added to PR
-   \[ \] PR is self reviewed
-   \[ \] Jira and state/status is updated and JIRA is updated with PR link
-   \[ \] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide
