### PR TITLE
CORTX-34105: [Fixed] Invalid status code incase of rejected requests by csm-agent

### DIFF
--- a/csm/core/agent/api.py
+++ b/csm/core/agent/api.py
@@ -313,7 +313,7 @@ class CsmRestApi(CsmApi, ABC):
         if CsmRestApi.__nreq >= CsmRestApi.__request_quota:
             # This block get executed when number of request reaches the request quota
             CsmRestApi.__nblocked += 1
-            msg = (f"[{request.request_id}] The request is blocked because the number of requests reached threshold\n"
+            msg = (f"The request is blocked because the number of requests reached threshold\n"
                    f"Number of requests blocked since the start is {CsmRestApi.__nblocked}")
             Log.warn(msg)
             return web.Response(status=429, text="Too many requests")


### PR DESCRIPTION
Signed-off-by: Rohit Kolapkar <rohit.j.kolapkar@seagate.com>

# Pull Request
## Problem Statement
- CORTX-34105
-   Due to throttler middleware logs modified in #895, agent is throwing 500 instead of 429 incase of no. of request exceeding CSM request-quota.

## Coding
>   Checklist for Author
-   \[x] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Unit and System Tests are added
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[ \] Testing was performed with RPM

## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[x] JIRA number/GitHub Issue added to PR
-   \[x] PR is self reviewed
-   \[x] Jira and state/status is updated and JIRA is updated with PR link
-   \[x] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide

<img width="325" alt="image" src="https://user-images.githubusercontent.com/36843912/187918162-bfe725b7-5a05-47a7-9ae2-d86ed01e3024.png">
