### PR TITLE
CORTX-34185: Incorrect data and metadata storage set values in the query deployment response

### DIFF
--- a/csm/core/data/models/rgw.py
+++ b/csm/core/data/models/rgw.py
@@ -49,6 +49,7 @@ class RgwErrors(Enum):
     " subordinate entities."
     BucketAlreadyExists = "Attempt to delete a resource that has attached"\
     " subordinate entities."
+    SlowDown = "kkkk"
 
 class RgwError:
     """Class that describes a non-successful result"""

--- a/csm/core/data/models/rgw.py
+++ b/csm/core/data/models/rgw.py
@@ -49,7 +49,6 @@ class RgwErrors(Enum):
     " subordinate entities."
     BucketAlreadyExists = "Attempt to delete a resource that has attached"\
     " subordinate entities."
-    SlowDown = "kkkk"
 
 class RgwError:
     """Class that describes a non-successful result"""

--- a/csm/core/services/query_deployment/topology_factory.py
+++ b/csm/core/services/query_deployment/topology_factory.py
@@ -85,10 +85,10 @@ class CortxTopology(ITopology):
         dix = payload.get(const.DIX)
         sns = payload.get(const.SNS)
         res = {
-            const.DATA: f"{dix.get(const.DATA)}+{dix.get(const.PARITY)}"\
-                        f"+{dix.get(const.SPARE)}",
-            const.METADATA: f"{sns.get(const.DATA)}+{sns.get(const.PARITY)}"\
-                        f"+{sns.get(const.SPARE)}"
+            const.DATA: f"{sns.get(const.DATA)}+{sns.get(const.PARITY)}"\
+                        f"+{sns.get(const.SPARE)}",
+            const.METADATA: f"{dix.get(const.DATA)}+{dix.get(const.PARITY)}"\
+                        f"+{dix.get(const.SPARE)}"
         }
         return res
 


### PR DESCRIPTION
Signed-off-by: Pranali Ugale <pranali.ugale@seagate.com>

# Pull Request
## Problem Statement
-    Jira: [CORTX-34185](https://jts.seagate.com/browse/CORTX-34185)
## Design
Updated document:
https://seagate-systems.atlassian.net/wiki/spaces/PRIVATECOR/pages/1024229377/Query+Deployment+REST+API+specification

## Coding
>   Checklist for Author
-   \[ \] Coding conventions are followed and code is consistent

## Testing 
>   Checklist for Author
-   \[ \] Unit and System Tests are added
-   \[ \] Test Cases cover Happy Path, Non-Happy Path and Scalability
-   \[ \] Testing was performed with RPM
- 
![image](https://user-images.githubusercontent.com/68841079/189812658-059c4b54-8be0-4506-80b9-78b83f8ac2d6.png)


## Impact Analysis
>   Checklist for Author/Reviewer/GateKeeper
-   \[ \] Interface change (if any) are documented
-   \[ \] Side effects on other features (deployment/upgrade)
-   \[ \] Dependencies on other component(s)

## Review Checklist 
>   Checklist for Author
-   \[ \] JIRA number/GitHub Issue added to PR
-   \[ \] PR is self reviewed
-   \[ \] Jira and state/status is updated and JIRA is updated with PR link
-   \[ \] Check if the description is clear and explained

## Documentation
>   Checklist for Author
-   \[ \] Changes done to WIKI / Confluence page / Quick Start Guide
